### PR TITLE
Differentiate appDrawer variant based on device type. On mobile devic…

### DIFF
--- a/docs/src/modules/components/AppDrawer.tsx
+++ b/docs/src/modules/components/AppDrawer.tsx
@@ -1,3 +1,4 @@
+import { Divider } from '@material-ui/core';
 import Drawer from '@material-ui/core/Drawer';
 import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
@@ -8,6 +9,7 @@ import { createStyles, makeStyles } from '@material-ui/styles';
 import clsx from 'clsx';
 import { useHoux } from 'houx';
 import React from 'react';
+import { isMobileOnly } from 'react-device-detect';
 
 import { useTranslation } from '../../../../i18n';
 import { Page } from '../../../../src/typings/data/import';
@@ -43,6 +45,7 @@ const useDrawerStyles = makeStyles((theme: Theme) =>
     hide: {
       display: 'none'
     },
+
     drawer: {
       width: drawerWidth,
       flexShrink: 0,
@@ -76,6 +79,9 @@ const useDrawerStyles = makeStyles((theme: Theme) =>
     content: {
       flexGrow: 1,
       padding: theme.spacing(3)
+    },
+    drawerPaper: {
+      width: drawerWidth
     }
   })
 );
@@ -121,6 +127,57 @@ const AppDrawer = (props: AppDrawerProps) => {
     const { canonical } = pathnameToLanguage(window.location.pathname);
     (canonicalRef as any).current = canonical;
   }, []);
+
+  const renderMobileDrawer = (navItems: JSX.Element) => {
+    return (
+      <Drawer
+        variant='temporary'
+        open={isDrawerOpen}
+        onClose={handleDrawerClose}
+        classes={{
+          paper: classes.drawerPaper
+        }}
+        ModalProps={{
+          keepMounted: true
+        }}
+      >
+        <div className={classes.toolbar}>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </div>
+        <Divider />
+        {navItems}
+      </Drawer>
+    );
+  };
+
+  const renderDesktopDrawer = (navItems: JSX.Element) => {
+    return (
+      <Drawer
+        variant='permanent'
+        className={clsx(classes.drawer, {
+          [classes.drawerOpen]: isDrawerOpen,
+          [classes.drawerClose]: !isDrawerOpen
+        })}
+        classes={{
+          paper: clsx({
+            [classes.drawerOpen]: isDrawerOpen,
+            [classes.drawerClose]: !isDrawerOpen
+          })
+        }}
+        open={isDrawerOpen}
+      >
+        <div className={classes.toolbar}>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </div>
+        <Divider />
+        {navItems}
+      </Drawer>
+    );
+  };
 
   const reduceChildRoutes = (
     { acc, currentPage }: DrawerReduceProps,
@@ -189,7 +246,7 @@ const AppDrawer = (props: AppDrawerProps) => {
     );
   };
 
-  let navItems;
+  let navItems: JSX.Element;
   if (pages && pages.length > 0) {
     navItems = renderNavItems(pages, {
       handleDrawerClose,
@@ -198,31 +255,14 @@ const AppDrawer = (props: AppDrawerProps) => {
     });
   }
 
-  return pages && pages.length > 0 ? (
-    <div className={classes.root}>
-      <Drawer
-        variant='permanent'
-        className={clsx(classes.drawer, {
-          [classes.drawerOpen]: isDrawerOpen,
-          [classes.drawerClose]: !isDrawerOpen
-        })}
-        classes={{
-          paper: clsx({
-            [classes.drawerOpen]: isDrawerOpen,
-            [classes.drawerClose]: !isDrawerOpen
-          })
-        }}
-        open={isDrawerOpen}
-      >
-        <div className={classes.toolbar}>
-          <IconButton onClick={handleDrawerClose}>
-            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-          </IconButton>
-        </div>
-        {navItems}
-      </Drawer>
-    </div>
-  ) : null;
+  if (pages && pages.length > 0) {
+    if (isMobileOnly) {
+      return renderMobileDrawer(navItems);
+    } else {
+      return renderDesktopDrawer(navItems);
+    }
+  }
+  return null;
 };
 
 export default AppDrawer;

--- a/docs/src/modules/components/AppFrame.tsx
+++ b/docs/src/modules/components/AppFrame.tsx
@@ -10,17 +10,6 @@ import AppToolBar from './AppToolBar';
 
 // import usePageTitle from './usePageTitle';
 
-export const languages = [
-  {
-    code: 'en',
-    text: '🇺🇸 English'
-  },
-  {
-    code: 'de',
-    text: '🇩🇪 Deutsch'
-  }
-];
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
@@ -104,35 +93,37 @@ const useDrawerStyles = makeStyles((theme: Theme) =>
         duration: theme.transitions.duration.enteringScreen
       })
     },
-    menuButton: {
-      marginRight: 36
-    },
-    hide: {
-      display: 'none'
-    },
-    drawer: {
-      width: drawerWidth,
-      flexShrink: 0,
-      whiteSpace: 'nowrap'
-    },
-    drawerOpen: {
-      width: drawerWidth,
-      transition: theme.transitions.create('width', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.enteringScreen
-      })
-    },
-    drawerClose: {
-      transition: theme.transitions.create('width', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen
-      }),
-      overflowX: 'hidden',
-      width: theme.spacing(7) + 1,
-      [theme.breakpoints.up('sm')]: {
-        width: theme.spacing(9) + 1
-      }
-    },
+
+    // menuButton: {
+    //   marginRight: 36
+    // },
+    // hide: {
+    //   display: 'none'
+    // }
+
+    // drawer: {
+    //   width: drawerWidth,
+    //   flexShrink: 0,
+    //   whiteSpace: 'nowrap'
+    // },
+    // drawerOpen: {
+    //   width: drawerWidth,
+    //   transition: theme.transitions.create('width', {
+    //     easing: theme.transitions.easing.sharp,
+    //     duration: theme.transitions.duration.enteringScreen
+    //   })
+    // },
+    // drawerClose: {
+    //   transition: theme.transitions.create('width', {
+    //     easing: theme.transitions.easing.sharp,
+    //     duration: theme.transitions.duration.leavingScreen
+    //   }),
+    //   overflowX: 'hidden',
+    //   width: theme.spacing(7) + 1,
+    //   [theme.breakpoints.up('sm')]: {
+    //     width: theme.spacing(9) + 1
+    //   }
+    // },
     toolbar: {
       display: 'flex',
       alignItems: 'center',
@@ -142,7 +133,9 @@ const useDrawerStyles = makeStyles((theme: Theme) =>
     },
     content: {
       flexGrow: 1,
-      padding: theme.spacing(3)
+      // padding: theme.spacing(3)
+      display: 'flex',
+      flexDirection: 'row'
     }
   })
 );
@@ -192,7 +185,7 @@ const AppFrame = ({ children, drawerStyleOverride }: AppFrameProps) => {
         isDrawerOpen={open}
         handleDrawerClose={handleDrawerClose}
       />
-      {children}
+      <main className={drawerClasses.content}>{children}</main>
     </div>
   );
 };

--- a/docs/src/modules/components/Editpage.tsx
+++ b/docs/src/modules/components/Editpage.tsx
@@ -2,6 +2,7 @@ import Button from '@material-ui/core/Button';
 import { useHoux } from 'houx';
 import React from 'react';
 
+import { useTranslation } from '../../../../i18n';
 import { RootState } from '../redux/reducers';
 
 const LOCALES = { zh: 'zh-CN', pt: 'pt-BR', es: 'es-ES' };
@@ -17,7 +18,8 @@ export const EditPage = ({ markdownLocation }: EditPageProps) => {
   const { state }: { state: RootState } = useHoux();
   const { userLanguage } = state.language;
 
-  //   const { t } = props;
+  const { t } = useTranslation();
+
   const crowdInLocale = LOCALES[userLanguage] || userLanguage;
   const crowdInPath = markdownLocation.substring(0, markdownLocation.lastIndexOf('/'));
 
@@ -35,8 +37,7 @@ export const EditPage = ({ markdownLocation }: EditPageProps) => {
       data-ga-event-action={userLanguage === 'de' ? undefined : 'edit-button'}
       data-ga-event-label={userLanguage === 'de' ? undefined : userLanguage}
     >
-      {/* {t('editPage')} */}
-      {'Edit Page'}
+      {t('editContent')}
     </Button>
   );
 };

--- a/docs/src/modules/components/md/MdDocs.tsx
+++ b/docs/src/modules/components/md/MdDocs.tsx
@@ -1,6 +1,7 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core';
 import { useHoux } from 'houx';
 import React from 'react';
+import { isMobileOnly } from 'react-device-detect';
 
 import { Page } from '../../../../../src/typings/data/import';
 import { RootState } from '../../redux/reducers';
@@ -27,10 +28,8 @@ export const useStyles = makeStyles((_theme: Theme) =>
     headerSpace: {
       flexGrow: 1
     },
-    headerItem: {
-      display: 'flex',
-      flexWrap: 'wrap',
-      flexDirection: 'column'
+    appFrameSpace: {
+      flexGrow: 1
     }
   })
 );
@@ -55,15 +54,21 @@ export const MdDocs = (props: MarkdownDocsProps) => {
 
   return (
     <AppFrame>
-      <AppTableOfContents content={content} />
       <AppContent>
-        <div className={classes.header}>
-          <Breadcrumbs />
-          <div className={classes.headerSpace} />
-          <EditPage markdownLocation={markdownLocation} sourceCodeRootUrl={SOURCE_CODE_ROOT_URL} />
-        </div>
+        {!isMobileOnly ? (
+          <div className={classes.header}>
+            <Breadcrumbs />
+            <div className={classes.headerSpace} />
+            <EditPage
+              markdownLocation={markdownLocation}
+              sourceCodeRootUrl={SOURCE_CODE_ROOT_URL}
+            />
+          </div>
+        ) : null}
         <MdElement content={content} />
       </AppContent>
+      <div className={classes.appFrameSpace} />
+      <AppTableOfContents content={content} />
     </AppFrame>
   );
 };

--- a/docs/src/modules/components/mdx/MdxDocs.tsx
+++ b/docs/src/modules/components/mdx/MdxDocs.tsx
@@ -2,6 +2,7 @@ import { Theme } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/styles';
 import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
+import { isMobileOnly } from 'react-device-detect';
 
 import AppContent from '../AppContent';
 import AppFrame from '../AppFrame';
@@ -193,6 +194,15 @@ export const useStyles = makeStyles((theme: Theme) =>
       '& img': {
         maxWidth: '100%'
       }
+    },
+
+    header: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      flexDirection: 'row'
+    },
+    appFrameSpace: {
+      flexGrow: 1
     }
   })
 );
@@ -219,11 +229,12 @@ export const MdxDocs = (props: MarkdownDocsProps) => {
 
   return (
     <AppFrame>
-      <AppTableOfContents content={raw} />
       <AppContent className={outerClasses.root}>
-        <Breadcrumbs />
+        {!isMobileOnly ? <Breadcrumbs /> : null}
         <div className={clsx(classes.root, 'markdown-body')}>{markdownFiles}</div>
       </AppContent>
+      <div className={classes.appFrameSpace} />
+      <AppTableOfContents content={raw} />
     </AppFrame>
   );
 };

--- a/docs/src/modules/components/useMarkdownDocsContents.tsx
+++ b/docs/src/modules/components/useMarkdownDocsContents.tsx
@@ -19,7 +19,6 @@ export const useMarkdownDocsContents = ({
   const contents = getContents(markdown);
   const headers = getHeaders(markdown);
 
-  debugger;
   const { pathname } = activePage;
 
   let markdownLocation = markdownLocationProp || pathname;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "next-i18next-serverless": "^1.1.33",
     "prism-react-renderer": "^0.1.7",
     "react": "^16.9.0",
+    "react-device-detect": "^1.9.9",
     "react-dom": "^16.9.0",
     "react-highlight": "^0.12.0",
     "react-i18next": "^10.12.3",

--- a/src/components/avatar/AvatarGrid.tsx
+++ b/src/components/avatar/AvatarGrid.tsx
@@ -33,8 +33,12 @@ const AvatarGrid = ({ letter }: AvatarGridProps) => {
 
   return (
     <Grid container justify='center' alignItems='center'>
-      {letter.map(l => {
-        return <Avatar className={classes.greenAvatar}>{l}</Avatar>;
+      {letter.map((l, i) => {
+        return (
+          <Avatar key={`${l}-${i}`} className={classes.greenAvatar}>
+            {l}
+          </Avatar>
+        );
       })}
     </Grid>
   );

--- a/static/locales/de/common.json
+++ b/static/locales/de/common.json
@@ -2,6 +2,8 @@
   "application-title": "Projekt Millipede",
   "change-language": "Sprache ändern",
   "github": "Github",
+  "toggleTheme": "Motiv hell / dunkel wechseln",
+  "editContent": "Inhalt bearbeiten",
   "openDrawer": "Drawer öffnen",
   "toc": "Inhaltsverzeichnis",
   "search": "Suche…",

--- a/static/locales/en/common.json
+++ b/static/locales/en/common.json
@@ -2,6 +2,8 @@
   "application-title": "Project Millipede",
   "change-language": "Change language",
   "github": "Github",
+  "toggleTheme": "Toggle light / dark theme",
+  "editContent": "Edit content",
   "openDrawer": "Open drawer",
   "toc": "Contents",
   "search": "Search…",


### PR DESCRIPTION
…es, the appdrawer variant is temporary. On larger screens including tablets its permanent (minimal drawer)

Use rendering conditionally based on the device type in other appliation parts (breadCrumbs, editPage). Improve layout of appContent / header / toc separation.

Further i18n

Other fixes