### PR TITLE
Material-UI drawer (mini variant) bug - Icon alignment. Set paddingLe…

### DIFF
--- a/docs/src/modules/components/AppContent.tsx
+++ b/docs/src/modules/components/AppContent.tsx
@@ -1,55 +1,27 @@
 import Container from '@material-ui/core/Container';
 import { createStyles, Theme } from '@material-ui/core/styles';
 import { makeStyles } from '@material-ui/styles';
-import clsx from 'clsx';
 import React from 'react';
 
-interface Props extends React.Props<any> {
-  className?: string;
-  disableToc: boolean;
-}
+interface Props extends React.Props<any> {}
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles((_theme: Theme) =>
   createStyles({
     root: {
       paddingTop: 80 + 16,
       flex: '1 1 100%',
       position: 'relative',
       maxWidth: '100%',
-      margin: '0 auto',
-      [theme.breakpoints.up('sm')]: {
-        paddingRight: theme.spacing(1),
-        maxWidth: 'calc(100% - 175px)'
-      },
-      [theme.breakpoints.up('lg')]: {
-        paddingLeft: theme.spacing(6),
-        paddingRight: theme.spacing(6),
-        maxWidth: 'calc(100% - 175px - 240px)'
-      }
-    },
-    disableToc: {
-      [theme.breakpoints.up('sm')]: {
-        maxWidth: 'calc(100%)'
-      },
-      [theme.breakpoints.up('lg')]: {
-        maxWidth: 'calc(100% - 240px)'
-      }
+      margin: '0 auto'
     }
   })
 );
 
-const AppContent = ({ className, disableToc, children }: Props) => {
+const AppContent = ({ children }: Props) => {
   const classes = useStyles({});
 
   return (
-    <Container
-      component='main'
-      id='main-content'
-      tabIndex={-1}
-      className={clsx(classes.root, className, {
-        [classes.disableToc]: disableToc
-      })}
-    >
+    <Container component='main' id='main-content' tabIndex={-1} className={classes.root}>
       {children}
     </Container>
   );

--- a/docs/src/modules/components/AppDrawerNavItem.tsx
+++ b/docs/src/modules/components/AppDrawerNavItem.tsx
@@ -1,5 +1,4 @@
 import { Collapse, Icon, List, ListItemIcon, ListItemText, Theme } from '@material-ui/core';
-import { blue } from '@material-ui/core/colors';
 import ListItem from '@material-ui/core/ListItem';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -20,12 +19,18 @@ interface AppDrawerNavItemProps extends React.Props<any> {
 
 type Props = AppDrawerNavItemProps & WithRouterProps;
 
-const useStyles = makeStyles((_theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    listItem: {
-      backgroundColor: blue[700]
-    },
-    root: { paddingLeft: '8px' }
+    listItemPadding: {
+      [theme.breakpoints.down('xs')]: {
+        paddingLeft: '16px',
+        paddingRight: '16px'
+      },
+      [theme.breakpoints.up('sm')]: {
+        paddingLeft: '24px',
+        paddingRight: '24px'
+      }
+    }
   })
 );
 
@@ -51,8 +56,8 @@ const AppDrawerNavItem = ({
   if (href) {
     return (
       <Link href={href}>
-        <ListItem button onClick={onClick}>
-          <ListItemIcon className={classes.root}>
+        <ListItem button onClick={onClick} className={classes.listItemPadding}>
+          <ListItemIcon>
             <Icon>{icon}</Icon>
           </ListItemIcon>
           <ListItemText primary={title} />
@@ -63,8 +68,8 @@ const AppDrawerNavItem = ({
 
   return (
     <>
-      <ListItem button onClick={handleClick}>
-        <ListItemIcon className={classes.root}>
+      <ListItem button onClick={handleClick} className={classes.listItemPadding}>
+        <ListItemIcon>
           <Icon>{icon}</Icon>
         </ListItemIcon>
         <ListItemText primary={title} />

--- a/docs/src/modules/components/AppFrame.tsx
+++ b/docs/src/modules/components/AppFrame.tsx
@@ -185,7 +185,7 @@ const AppFrame = ({ children, drawerStyleOverride }: AppFrameProps) => {
         isDrawerOpen={open}
         handleDrawerClose={handleDrawerClose}
       />
-      <main className={drawerClasses.content}>{children}</main>
+      <div className={drawerClasses.content}>{children}</div>
     </div>
   );
 };

--- a/docs/src/modules/components/AppTableOfContents.tsx
+++ b/docs/src/modules/components/AppTableOfContents.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
       top: 70,
       // Fix IE 11 position sticky issue.
       marginTop: 70,
-      width: 175,
+      width: 225,
       flexShrink: 0,
       order: 2,
       position: 'sticky',

--- a/docs/src/modules/components/md/MdDocs.tsx
+++ b/docs/src/modules/components/md/MdDocs.tsx
@@ -40,7 +40,7 @@ export const MdDocs = (props: MarkdownDocsProps) => {
       /> */}
       <Head />
       {disableToc ? null : <AppTableOfContents content={content} />}
-      <AppContent disableToc={disableToc}>
+      <AppContent>
         <AppContentHeader markdownLocation={markdownLocation} />
         <MdElement content={content} />
       </AppContent>

--- a/docs/src/modules/components/mdx/MdxDocs.tsx
+++ b/docs/src/modules/components/mdx/MdxDocs.tsx
@@ -30,12 +30,11 @@ interface MarkdownDocsProps extends React.Props<any> {
   ast?: any;
   headingsMap?: any;
   raw?: string;
-  outerClasses?: any;
   disableToc?: boolean;
 }
 
 export const MdxDocs = (props: MarkdownDocsProps) => {
-  const { content, raw, outerClasses = {}, disableToc = false } = props;
+  const { content, raw, disableToc = false, children } = props;
 
   const classes = useStyles({});
 
@@ -47,10 +46,10 @@ export const MdxDocs = (props: MarkdownDocsProps) => {
       /> */}
       <Head />
       {disableToc ? null : <AppTableOfContents content={raw} />}
-      <AppContent className={outerClasses.root} disableToc={disableToc}>
+      <AppContent>
         <AppContentHeader />
         <div className={clsx(classes.root, 'markdown-body')}>
-          <MdxElement content={content} />
+          {children || <MdxElement content={content} />}
         </div>
       </AppContent>
     </AppFrame>


### PR DESCRIPTION
…ft / paddingRight based on breakpoints

Replace duplicate main tag, created in AppContent (Container component="main") with div

Increase toc width 175 - 225px

Take out padding, maxWidth style logic based on disableToc. Remove prop outerClasses from MdxDocs.