### PR TITLE
Add option to share post through mail. Improve SpeedDial animation.

### DIFF
--- a/docs/src/modules/components/AppContentFooter.tsx
+++ b/docs/src/modules/components/AppContentFooter.tsx
@@ -1,0 +1,85 @@
+import { Button, Container, createStyles, Divider, makeStyles, Theme } from '@material-ui/core';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import { useHoux } from 'houx';
+import React from 'react';
+
+import { useTranslation } from '../../../../i18n';
+import { RootState } from '../redux/reducers';
+
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    footer: {
+      marginTop: theme.spacing(12)
+    },
+    pagination: {
+      margin: theme.spacing(3, 0, 4),
+      display: 'flex',
+      justifyContent: 'space-between'
+    },
+    pageLinkButton: {
+      textTransform: 'none',
+      fontWeight: theme.typography.fontWeightRegular
+    },
+    chevronLeftIcon: {
+      marginRight: theme.spacing(1)
+    },
+    chevronRightIcon: {
+      marginLeft: theme.spacing(1)
+    }
+  })
+);
+
+export const AppContentFooter = () => {
+  const classes = useStyles({});
+
+  const { t } = useTranslation();
+
+  const {
+    state: {
+      navigation: { flattenedPages, activePage }
+    }
+  }: { state: RootState } = useHoux();
+
+  const currentPageNum = flattenedPages.findIndex(page => page.pathname === activePage.pathname);
+  const prevPage = flattenedPages[currentPageNum - 1];
+  const nextPage = flattenedPages[currentPageNum + 1];
+
+  return (
+    <Container component='footer' className={classes.footer}>
+      <React.Fragment>
+        <Divider />
+        <div className={classes.pagination}>
+          {prevPage ? (
+            <Button
+              // component={Link}
+              // naked
+              href={prevPage.pathname}
+              size='large'
+              className={classes.pageLinkButton}
+            >
+              <ChevronLeftIcon fontSize='small' className={classes.chevronLeftIcon} />
+              {t(`pages.${prevPage.pathname}`)}
+            </Button>
+          ) : (
+            <div />
+          )}
+          {nextPage ? (
+            <Button
+              // component={Link}
+              // naked
+              href={nextPage.pathname}
+              size='large'
+              className={classes.pageLinkButton}
+            >
+              {t(`pages.${nextPage.pathname}`)}
+              <ChevronRightIcon fontSize='small' className={classes.chevronRightIcon} />
+            </Button>
+          ) : null}
+        </div>
+      </React.Fragment>
+    </Container>
+  );
+};
+
+export default AppContentFooter;

--- a/docs/src/modules/components/AppContentHeader.tsx
+++ b/docs/src/modules/components/AppContentHeader.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { isMobileOnly } from 'react-device-detect';
 
 import Breadcrumbs from './common/breadcrumbs';
-import Share from './common/share';
 import Editpage from './Editpage';
 
 export const useStyles = makeStyles((_theme: Theme) =>
@@ -11,14 +10,8 @@ export const useStyles = makeStyles((_theme: Theme) =>
     headerRow: {
       display: 'flex',
       flexDirection: 'row',
-      flexGrow: 1
-    },
-    headerColumn: {
-      display: 'flex',
-      flexDirection: 'column'
-    },
-    headerSpace: {
-      flexGrow: 1
+      flexGrow: 1,
+      height: '56px'
     }
   })
 );
@@ -32,25 +25,14 @@ const SOURCE_CODE_ROOT_URL = 'https://github.com/gurkerl83/millipede-docs/blob/m
 export const AppContentHeader = ({ markdownLocation }: MarkdownDocsProps) => {
   const classes = useStyles({});
 
-  return (
-    <div className={classes.headerColumn}>
-      {!isMobileOnly ? (
-        <div className={classes.headerRow}>
-          <Breadcrumbs />
-          {markdownLocation ? (
-            <Editpage
-              markdownLocation={markdownLocation}
-              sourceCodeRootUrl={SOURCE_CODE_ROOT_URL}
-            />
-          ) : null}
-        </div>
+  return !isMobileOnly ? (
+    <div className={classes.headerRow}>
+      <Breadcrumbs />
+      {markdownLocation ? (
+        <Editpage markdownLocation={markdownLocation} sourceCodeRootUrl={SOURCE_CODE_ROOT_URL} />
       ) : null}
-      <div className={classes.headerRow}>
-        <div className={classes.headerSpace} />
-        <Share share={'test share'} />
-      </div>
     </div>
-  );
+  ) : null;
 };
 
 export default AppContentHeader;

--- a/docs/src/modules/components/common/share/Icon.tsx
+++ b/docs/src/modules/components/common/share/Icon.tsx
@@ -1,3 +1,4 @@
+import AlternateEmailIcon from '@material-ui/icons/AlternateEmail';
 import Assignment from '@material-ui/icons/Assignment';
 import FacebookIcon from '@material-ui/icons/Facebook';
 import LinkedInIcon from '@material-ui/icons/LinkedIn';
@@ -9,6 +10,8 @@ const Icon = ({ id }) => {
   switch (id) {
     case 'copy-link':
       return <Assignment />;
+    case 'mail':
+      return <AlternateEmailIcon />;
     case 'facebook':
       return <FacebookIcon />;
     case 'twitter':

--- a/docs/src/modules/components/common/share/Markup.tsx
+++ b/docs/src/modules/components/common/share/Markup.tsx
@@ -2,11 +2,13 @@ import CloseIcon from '@material-ui/icons/Close';
 import ShareIcon from '@material-ui/icons/Share';
 import SpeedDial from '@material-ui/lab/SpeedDial';
 import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
+import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
 import { TFunction } from 'next-i18next-serverless';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { isMobile } from 'react-device-detect';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import {
   Interaction,
@@ -14,6 +16,7 @@ import {
   SocialData,
   URIPathParamsFacebook,
   URIPathParamsLinkedIn,
+  URIPathParamsMail,
   URIPathParamsTwitter,
   URIPathParamsWhatsApp,
 } from '../../../../../../src/typings/share/social';
@@ -22,6 +25,10 @@ import Icon from './Icon';
 import Modal from './Modal';
 
 const isBrowser = typeof window !== 'undefined';
+
+const StyledSpeedDial = styled(SpeedDial)`
+  align-self: flex-start;
+`;
 
 export interface MarkupProps {
   sharingOpen: boolean;
@@ -46,6 +53,16 @@ const getSharing = (data: SocialData, t: TFunction) => {
       type: Interaction.SHARE_LOCAL,
       title: t('copy-link'),
       url: ''
+    },
+    {
+      id: 'mail',
+      type: Interaction.SHARE_MAIL,
+      title: `${t('share-on')} Mail`,
+      url: 'mailto://',
+      params: {
+        subject: share,
+        body: share
+      } as URIPathParamsMail
     },
     {
       id: 'facebook',
@@ -115,6 +132,16 @@ const createObjects = (
       }
     };
   }
+  if (type === Interaction.SHARE_MAIL) {
+    return {
+      title,
+      icon: <Icon id={id} />,
+      action: () => {
+        toggleSharingOpen();
+        createNewTab(`${url}${objectToGetParams(params)}`);
+      }
+    };
+  }
 
   return {
     title,
@@ -132,7 +159,7 @@ const creataShareLink = ({ title, icon, action }) => (
     icon={icon}
     tooltipTitle={title}
     onClick={action}
-    tooltipPlacement={'bottom'}
+    tooltipPlacement={'left'}
   />
 );
 
@@ -168,15 +195,18 @@ const Markup = ({ sharingOpen, toggleSharingOpen, toggleModal, modal }: MarkupPr
 
   return (
     <React.Fragment>
-      <SpeedDial
-        ariaLabel='SpeedDial openIcon example'
-        icon={sharingOpen ? <CloseIcon /> : <ShareIcon />}
+      <StyledSpeedDial
+        ariaLabel={t('share-post')}
+        icon={<SpeedDialIcon icon={<ShareIcon />} openIcon={<CloseIcon />} />}
         onClick={toggleSharingOpen}
+        onClose={toggleSharingOpen}
+        onMouseEnter={toggleSharingOpen}
+        onMouseLeave={toggleSharingOpen}
         open={sharingOpen}
-        direction='left'
+        direction='down'
       >
         {createButtons(toggleModal, toggleSharingOpen, router.pathname, t)}
-      </SpeedDial>
+      </StyledSpeedDial>
       <Modal open={!!modal} closeModal={() => toggleModal(null)} url={modal} />
     </React.Fragment>
   );

--- a/docs/src/modules/components/md/MdDocs.tsx
+++ b/docs/src/modules/components/md/MdDocs.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Page } from '../../../../../src/typings/data/import';
 import { RootState } from '../../redux/reducers';
 import AppContent from '../AppContent';
+import AppContentFooter from '../AppContentFooter';
 import AppContentHeader from '../AppContentHeader';
 import AppFrame from '../AppFrame';
 import AppTableOfContents from '../AppTableOfContents';
@@ -43,6 +44,7 @@ export const MdDocs = (props: MarkdownDocsProps) => {
       <AppContent>
         <AppContentHeader markdownLocation={markdownLocation} />
         <MdElement content={content} />
+        <AppContentFooter />
       </AppContent>
     </AppFrame>
   );

--- a/docs/src/modules/components/mdx/MdxDocs.tsx
+++ b/docs/src/modules/components/mdx/MdxDocs.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import React from 'react';
 
 import AppContent from '../AppContent';
+import AppContentFooter from '../AppContentFooter';
 import AppContentHeader from '../AppContentHeader';
 import AppFrame from '../AppFrame';
 import AppTableOfContents from '../AppTableOfContents';
@@ -51,6 +52,7 @@ export const MdxDocs = (props: MarkdownDocsProps) => {
         <div className={clsx(classes.root, 'markdown-body')}>
           {children || <MdxElement content={content} />}
         </div>
+        <AppContentFooter />
       </AppContent>
     </AppFrame>
   );

--- a/docs/src/modules/components/mdx/MdxElement.tsx
+++ b/docs/src/modules/components/mdx/MdxElement.tsx
@@ -1,14 +1,36 @@
-import { Typography } from '@material-ui/core';
+import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
 import { MDXProvider } from '@mdx-js/react';
 import React from 'react';
 
 import { InteractiveHead } from '../../../markdown/components/head';
+import Share from '../common/share';
 
 interface MDXProps extends React.Props<any> {
   id: string;
 }
 
-const h1 = ({ children }: MDXProps) => <Typography variant='h1'>{children}</Typography>;
+export const useStyles = makeStyles((_theme: Theme) =>
+  createStyles({
+    headerRow: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: '56px'
+    }
+  })
+);
+
+const h1 = ({ children }: MDXProps) => {
+  const classes = useStyles({});
+  return (
+    <div className={classes.headerRow}>
+      <Typography variant='h1' style={{ paddingRight: '16px' }}>
+        {children}
+      </Typography>
+      <Share share={'test share'} />
+    </div>
+  );
+};
 const h2 = ({ children, id }: MDXProps) => (
   <InteractiveHead component='h2' id={id}>
     {children}

--- a/docs/src/modules/redux/features/navigation/reducer.ts
+++ b/docs/src/modules/redux/features/navigation/reducer.ts
@@ -1,20 +1,22 @@
 import { Page } from '../../../../../../src/typings/data/import';
 import { loadPages } from '../../../../pages';
-import { determineActivePage } from '../../../utils/router';
+import { determineActivePage, flattenPages } from '../../../utils/router';
 import { StoreAction } from '../actionType';
 import { CHANGE_NAVIGATION, LOAD_PAGES, SETUP_NAVIGATION } from './actionTypes';
 
 interface Props {
-  activePage: Page;
   pages: Array<Page>;
+  flattenedPages: Array<Page>;
+  activePage: Page;
 }
 
 export const initialState: Props = {
+  pages: [],
+  flattenedPages: [],
   activePage: {
     pathname: 'Test',
     title: ''
-  },
-  pages: []
+  }
 };
 
 const navigationReducer = (state = initialState, action: StoreAction) => {
@@ -31,9 +33,11 @@ const navigationReducer = (state = initialState, action: StoreAction) => {
       };
     case LOAD_PAGES: {
       const pages = loadPages(action.payload.pathname, state.pages);
+      const flattenedPages = flattenPages(pages);
       return {
         ...state,
         pages,
+        flattenedPages,
         activePage: determineActivePage(pages, action.payload.pathname)
       };
     }

--- a/docs/src/modules/utils/router.ts
+++ b/docs/src/modules/utils/router.ts
@@ -38,9 +38,20 @@ const determineCurrenPathname = (pathname: string) => {
   return pathname;
 };
 
-export const determineActivePage = (pages: Array<Page>, pathname: string) => {
+const determineActivePage = (pages: Array<Page>, pathname: string) => {
   const currentPathname = determineCurrenPathname(pathname);
   return findActivePage(pages, currentPathname);
 };
 
-export { findActivePage, determineCurrenPathname };
+const flattenPages = (pages: Array<Page>, current: Array<Page> = []) => {
+  return pages.reduce((items, item) => {
+    if (item.children && item.children.length > 1) {
+      items = flattenPages(item.children, items);
+    } else {
+      items.push(item.children && item.children.length === 1 ? item.children[0] : item);
+    }
+    return items;
+  }, current);
+};
+
+export { findActivePage, determineCurrenPathname, determineActivePage, flattenPages };

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@material-ui/core": "^4.5.0",
+    "@material-ui/core": "^4.5.1",
     "@material-ui/docs": "^4.0.0-beta.0",
-    "@material-ui/icons": "^4.4.3",
+    "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.27",
     "@material-ui/styles": "^4.5.0",
     "@mdx-js/mdx": "^1.5.1",
@@ -52,7 +52,7 @@
     "lodash": "^4.17.15",
     "mdast-util-to-string": "^1.0.6",
     "mdast-util-toc": "^4.2.0",
-    "next": "^9.1.1",
+    "next": "^9.1.2-canary.2",
     "next-i18next-serverless": "^1.1.43",
     "polished": "^3.4.1",
     "react": "^16.10.2",
@@ -76,10 +76,10 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-    "@babel/preset-env": "^7.6.2",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/preset-env": "^7.6.3",
+    "@babel/preset-react": "^7.6.3",
     "@types/dotenv": "^6.1.1",
-    "@types/lodash": "^4.14.142",
+    "@types/lodash": "^4.14.144",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
     "@types/webpack-merge": "^4.1.5",
@@ -102,8 +102,8 @@
     "raw-loader": "^3.1.0",
     "ts-loader": "^6.2.0",
     "ts-node": "^8.4.1",
-    "typescript": "^3.6.3",
-    "webpack": "^4.41.0",
+    "typescript": "^3.6.4",
+    "webpack": "^4.41.1",
     "webpack-merge": "^4.2.2"
   }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -9,6 +9,7 @@
   "search": "Suche…",
   "next": "Weiter",
   "back": "Zurück",
+  "share-post": "Artikel teilen",
   "copy-link": "Link kopieren",
   "share-on": "Teilen auf",
   "error-with-status": "Auf dem Server ist ein Fehler ({{statusCode}}) aufgetreten",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -9,6 +9,7 @@
   "search": "Search…",
   "next": "Next",
   "back": "Back",
+  "share-post": "Share post",
   "copy-link": "Copy link",
   "share-on": "Share on",
   "error-with-status": "A {{statusCode}} error occurred on server",

--- a/src/typings/share/social.ts
+++ b/src/typings/share/social.ts
@@ -4,6 +4,7 @@
 // Figure out if facebook accepts hashtag Array<string> - consolidate hashtag, hashtags
 
 export type SocialMediaURIPathParams =
+  | URIPathParamsMail
   | URIPathParamsFacebook
   | URIPathParamsLinkedIn
   | URIPathParamsTwitter
@@ -13,6 +14,11 @@ export interface SocialData {
   baseUrl: string;
   hashTags: Array<string>;
   share: string;
+}
+
+export interface URIPathParamsMail {
+  subject: string;
+  body: string;
 }
 
 export interface URIPathParamsFacebook {
@@ -43,6 +49,7 @@ export interface URIPathParamsWhatsApp {
 export enum Interaction {
   SHARE,
   SHARE_LOCAL,
+  SHARE_MAIL,
   CONTRIBUTE
 }
 


### PR DESCRIPTION
Remove share component from contentHeader, instead use it in any page on the highest level (h1).

Add appContentFooter for back and forth navigation of pages. Adjust navigation reducer to generate a flattened page representation.

Fragments missed on the first commit

Update translations

Update dependencies