### PR TITLE
Remove confusing code from mdx-parser

### DIFF
--- a/docs/src/modules/components/AppDrawer.tsx
+++ b/docs/src/modules/components/AppDrawer.tsx
@@ -208,8 +208,8 @@ const AppDrawer = (props: AppDrawerProps) => {
       return [
         ...acc,
         <AppDrawerNavItem
+          key={currentPage.pathname}
           depth={depth}
-          key={title}
           openImmediately={topLevel || !!currentPage.subheader}
           title={title}
           icon={currentPage.icon}
@@ -234,8 +234,8 @@ const AppDrawer = (props: AppDrawerProps) => {
     return [
       ...acc,
       <AppDrawerNavItem
+        key={currentPage.pathname}
         depth={depth}
-        key={title}
         title={title}
         icon={icon}
         href={pathname}
@@ -249,9 +249,13 @@ const AppDrawer = (props: AppDrawerProps) => {
     pages: Array<Page>,
     drawerContext: DrawerContextProps
   ) => {
+    const {
+      activePage: { pathname }
+    } = drawerContext;
+
     const initValue: Array<JSX.Element> = [];
     return (
-      <List dense>
+      <List key={pathname} dense>
         {pages.reduce(
           (acc, currentPage) =>
             reduceChildRoutes({ acc, currentPage }, drawerContext),

--- a/docs/src/modules/components/AppDrawerNavItem.tsx
+++ b/docs/src/modules/components/AppDrawerNavItem.tsx
@@ -3,9 +3,7 @@ import ListItem from '@material-ui/core/ListItem';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
-import { WithRouterProps } from 'next/dist/client/with-router';
 import Link from 'next/link';
-import { withRouter } from 'next/router';
 import React, { useState } from 'react';
 
 import { Icon } from '../../../../src/typings/data/import';
@@ -21,7 +19,7 @@ interface AppDrawerNavItemProps extends React.Props<any> {
   highlight: boolean;
 }
 
-type Props = AppDrawerNavItemProps & WithRouterProps;
+type Props = AppDrawerNavItemProps;
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -42,6 +40,7 @@ const useStyles = makeStyles((theme: Theme) =>
 // e.g. topics PET and PID/P have in common.
 
 const AppDrawerNavItem = ({
+  key,
   title,
   icon,
   href,
@@ -60,7 +59,12 @@ const AppDrawerNavItem = ({
   if (href) {
     return (
       <Link href={href}>
-        <ListItem button onClick={onClick} className={classes.listItemPadding}>
+        <ListItem
+          button
+          onClick={onClick}
+          className={classes.listItemPadding}
+          key={key}
+        >
           <ListItemIcon>
             <CustomIcon icon={icon} />
           </ListItemIcon>
@@ -76,6 +80,7 @@ const AppDrawerNavItem = ({
         button
         onClick={handleClick}
         className={classes.listItemPadding}
+        key={key}
       >
         <ListItemIcon>
           <CustomIcon icon={icon} />
@@ -92,4 +97,4 @@ const AppDrawerNavItem = ({
   );
 };
 
-export default withRouter(AppDrawerNavItem);
+export default AppDrawerNavItem;

--- a/docs/src/modules/components/AppWrapper.tsx
+++ b/docs/src/modules/components/AppWrapper.tsx
@@ -1,52 +1,40 @@
 import { jssPreset, StylesProvider } from '@material-ui/core/styles';
 import { useHoux } from 'houx';
 import { create } from 'jss';
-import { WithRouterProps } from 'next/dist/client/with-router';
-import { withRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import React, { ReactNode, useEffect } from 'react';
 import ReactGA from 'react-ga';
 
 import { NavigationActions } from '../redux/features/actionType';
 import { loadPages } from '../redux/features/navigation/actions';
 import { ThemeProvider } from './ThemeProvider';
 
-interface OProps extends React.Props<any> {}
+interface Props {
+  children?: ReactNode;
+}
 
-type Props = OProps & WithRouterProps;
-
-// Configure JSS
 const jss = create({
   plugins: [...jssPreset().plugins]
+  // insertionPoint: process.browser ? document.querySelector('#insertion-point-jss') : null,
 });
 
-// const generateClassName = createGenerateClassName();
+const AppWrapper = ({ children }: Props) => {
+  const router = useRouter();
 
-const AppWrapper = ({ children, router }: Props) => {
-  // Remove the server-side injected CSS.
-  // const jssStyles = document.querySelector("#jss-server-side");
-  // if (jssStyles) {
-  //   jssStyles.parentNode.removeChild(jssStyles);
-  // }
-
-  const { dispatch }: { dispatch: React.Dispatch<NavigationActions> } = useHoux();
+  const {
+    dispatch
+  }: { dispatch: React.Dispatch<NavigationActions> } = useHoux();
 
   useEffect(() => {
     dispatch(loadPages(router.pathname));
     ReactGA.pageview(router.pathname);
   }, [router.pathname]);
 
-  // return (
-  //   <StylesProvider generateClassName={generateClassName} jss={jss}>
-  //     {children}
-  //   </StylesProvider>
-  // );
-
   return (
     <StylesProvider jss={jss}>
       <ThemeProvider>{children}</ThemeProvider>
-      {/* <SideEffects /> */}
     </StylesProvider>
   );
 };
 
-export default withRouter(AppWrapper);
+export default AppWrapper;

--- a/docs/src/modules/components/Head.tsx
+++ b/docs/src/modules/components/Head.tsx
@@ -1,16 +1,12 @@
-import { WithRouterProps } from 'next/dist/client/with-router';
 import NextHead from 'next/head';
-import { withRouter } from 'next/router';
 import React, { FC } from 'react';
 
 import { useTranslation } from '../../../../i18n';
 import { MetaProps } from '../../../../src/typings/share';
 
-interface OProps extends WithRouterProps {
+interface Props {
   meta?: MetaProps;
 }
-
-type Props = OProps & WithRouterProps;
 
 const Head: FC<Props> = ({
   meta: {
@@ -43,4 +39,4 @@ Head.defaultProps = {
   meta: {}
 };
 
-export default withRouter(Head);
+export default Head;

--- a/docs/src/modules/components/common/breadcrumbs/Breadcrumbs.tsx
+++ b/docs/src/modules/components/common/breadcrumbs/Breadcrumbs.tsx
@@ -1,13 +1,12 @@
 import { Breadcrumbs as MaterialBreadcrumbs, Button } from '@material-ui/core';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
-import { WithRouterProps } from 'next/dist/client/with-router';
 import Link from 'next/link';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import React from 'react';
 
 import { useTranslation } from '../../../../../../i18n';
 
-interface Props extends WithRouterProps {}
+interface Props {}
 
 interface BreadCrumb {
   link: string;
@@ -21,10 +20,12 @@ export const createBreadcrumbs = (pathname: string): Array<BreadCrumb> =>
       link: `/${arr.slice(0, index + 1).join('/')}`
     }));
 
-const Breadcrumbs: React.FC<Props> = props => {
+const Breadcrumbs: React.FC<Props> = () => {
   const { t } = useTranslation();
 
-  const breadcrumbs = createBreadcrumbs(props.router.pathname);
+  const router = useRouter();
+
+  const breadcrumbs = createBreadcrumbs(router.pathname);
 
   if (breadcrumbs.length < 2) {
     return null;
@@ -58,4 +59,4 @@ const Breadcrumbs: React.FC<Props> = props => {
   );
 };
 
-export default withRouter(Breadcrumbs);
+export default Breadcrumbs;

--- a/docs/src/modules/components/common/button/MillipedeLink.tsx
+++ b/docs/src/modules/components/common/button/MillipedeLink.tsx
@@ -17,7 +17,6 @@ interface TProps {
   // router?: PublicRouterInstance;
 }
 
-// type Props = WithRouterProps & TProps;
 type Props = TProps;
 
 export class MillipedeLink extends Component<Props, {}> {
@@ -26,7 +25,9 @@ export class MillipedeLink extends Component<Props, {}> {
     const { naked, href, onClick, target, rel, className } = this.props;
 
     if (naked) {
-      return <NextLinkButton component={Link} href={href} className={className} />;
+      return (
+        <NextLinkButton component={Link} href={href} className={className} />
+      );
     }
 
     return (

--- a/docs/src/modules/components/loader/MDXContentLoader.tsx
+++ b/docs/src/modules/components/loader/MDXContentLoader.tsx
@@ -11,8 +11,7 @@ const load = (pathSlice = '', userLanguage = ''): any =>
       return {
         content: result.default,
         raw: result.raw,
-        // meta: result.metadata2
-        meta: result.a,
+        meta: result.meta,
         timeToRead: result.timeToRead
       };
     })

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -76,7 +76,10 @@ export interface PathnameToLanguage {
 export const pathnameToLanguage = (pathname: string): PathnameToLanguage => {
   const userLanguage = pathname.substring(1, 3);
 
-  if (LANGUAGES.indexOf(userLanguage) !== -1 && pathname.indexOf(`/${userLanguage}/`) === 0) {
+  if (
+    LANGUAGES.indexOf(userLanguage) !== -1 &&
+    pathname.indexOf(`/${userLanguage}/`) === 0
+  ) {
     return {
       userLanguage,
       canonical: userLanguage === 'en' ? pathname : pathname.substring(3)

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -14,19 +14,19 @@ export const loadPages = (pathname: string, currentPages: Array<Page>) => {
     return [];
   }
 
-  if (
-    pagesPET.filter(link => {
-      return _.some([link, ...(link.children || [])], linkIncludesText);
-    }).length > 0
-  ) {
-    return [
-      ...pagesCommon,
-      ...pagesRethinkSecurity,
-      ...pagesPET,
-      ...pagesPerspective,
-      ...pagesDiscoverMore
-    ];
-  }
+  // if (
+  //   pagesPET.filter(link => {
+  //     return _.some([link, ...(link.children || [])], linkIncludesText);
+  //   }).length > 0
+  // ) {
+  //   return [
+  //     // ...pagesCommon,
+  //     ...pagesRethinkSecurity,
+  //     ...pagesPET,
+  //     ...pagesPerspective,
+  //     ...pagesDiscoverMore
+  //   ];
+  // }
 
   if (
     pagesPIDP.filter(link => {
@@ -34,7 +34,17 @@ export const loadPages = (pathname: string, currentPages: Array<Page>) => {
     }).length > 0
   ) {
     return [
-      ...pagesCommon,
+      // ...pagesCommon,
+      ...pagesRethinkSecurity,
+      ...pagesPIDP,
+      ...pagesPerspective,
+      ...pagesDiscoverMore
+    ];
+  }
+
+  if (currentPages.length === 0) {
+    return [
+      // ...pagesCommon,
       ...pagesRethinkSecurity,
       ...pagesPIDP,
       ...pagesPerspective,
@@ -66,13 +76,13 @@ export const loadPages = (pathname: string, currentPages: Array<Page>) => {
     return [...currentPages];
   }
 
-  if (
-    pagesCommon.filter(link => {
-      return _.some([link, ...(link.children || [])], linkIncludesText);
-    }).length > 0
-  ) {
-    return [...currentPages];
-  }
+  // if (
+  //   pagesCommon.filter(link => {
+  //     return _.some([link, ...(link.children || [])], linkIncludesText);
+  //   }).length > 0
+  // ) {
+  //   return [...currentPages];
+  // }
 };
 
 export const defaultIcon: Icon = {
@@ -85,59 +95,48 @@ export const defaultFAIcon: Icon = {
   name: ''
 };
 
-export const pagesCommon: Array<Page> = [
-  {
-    pathname: '/guides',
-    icon: { ...defaultIcon, name: 'explore' },
-    highlight: true,
-    children: [
-      {
-        pathname: '/guides/landing',
-        icon: defaultIcon,
-        highlight: true
-      },
-      {
-        pathname: '/guides/api',
-        icon: { ...defaultIcon, name: 'code' },
-        highlight: true
-      }
-    ]
-  },
-  {
-    pathname: '/',
-    displayNav: false
-  }
-];
+// export const pagesCommon: Array<Page> = [
+//   {
+//     pathname: '/guides',
+//     icon: { ...defaultIcon, name: 'explore' },
+//     children: [
+//       {
+//         pathname: '/guides/api',
+//         icon: { ...defaultIcon, name: 'code' }
+//       }
+//     ]
+//   },
+//   {
+//     pathname: '/',
+//     displayNav: false
+//   }
+// ];
 
 export const pagesDiscoverMore: Array<Page> = [
   {
     pathname: '/discover-more',
     icon: { ...defaultIcon, name: 'info' },
-    highlight: true,
     children: [
       {
         pathname: '/discover-more/support',
         icon: {
           ...defaultIcon,
           name: 'contact_support'
-        },
-        highlight: true
+        }
       },
       {
         pathname: '/discover-more/team',
         icon: {
           ...defaultIcon,
           name: 'group_work'
-        },
-        highlight: true
+        }
       },
       {
         pathname: '/discover-more/organisation',
         icon: {
           ...defaultIcon,
           name: 'business'
-        },
-        highlight: true
+        }
       }
     ]
   }

--- a/docs/src/pages/perspective/strategy/index-de.mdx
+++ b/docs/src/pages/perspective/strategy/index-de.mdx
@@ -1,4 +1,14 @@
-import WrappedByExample from './use';
+---
+title: Interdisziplinäre Problemstellung
+description: Stakeholder und Herangehensweisen
+keywords:
+  politische Bildung, Journalismus, Psychologie, Informatik / Mathematik,
+  praktischer Mehrwert, unscharfe Handlungsempfehlungen, Forderung,
+author: Markus Gritsch
+date: 19.1.2020
+---
+
+import WrappedByExample from "./use";
 
 # Über Disziplinen hinweg denken
 

--- a/docs/src/pages/perspective/strategy/index.mdx
+++ b/docs/src/pages/perspective/strategy/index.mdx
@@ -1,3 +1,13 @@
+---
+title: Interdisciplinary problem definition
+description: Stakeholders and methods of approach
+keywords:
+  political education, journalism, psychology, computer science / mathematics,
+  practical added value, diffuse recommendations for action, requirement,
+author: Markus Gritsch
+date: 19.1.2020
+---
+
 import WrappedByExample from './use';
 
 # Thinking beyond disciplines

--- a/docs/src/pages/pidp/use-case/recognition/index-de.mdx
+++ b/docs/src/pages/pidp/use-case/recognition/index-de.mdx
@@ -6,15 +6,7 @@ author: Markus Gritsch
 date: 27.12.2019
 ---
 
-export const a = {
-  title: "Unmittelbare Wahrnehmung ergänzender Inhalte",
-  description: "Problemstellung",
-  keywords: "Security, Privacy, PET, PID/P",
-  author: "Markus Gritsch",
-  date: "27.12.2019"
-};
-
-import Demonstrator from "./demonstrator";
+import Demonstrator from './demonstrator';
 
 # Unmittelbare Wahrnehmung ergänzender Inhalte
 

--- a/docs/src/pages/pidp/use-case/recognition/index.mdx
+++ b/docs/src/pages/pidp/use-case/recognition/index.mdx
@@ -6,15 +6,7 @@ author: Markus Gritsch
 date: 27.12.2019
 ---
 
-export const a = {
-  title: "Instant perception of supplementary content",
-  description: "Problem statement",
-  keywords: "Security, Privacy, PET, PID/P",
-  author: "Markus Gritsch",
-  date: "27.12.2019"
-};
-
-import Demonstrator from "./demonstrator";
+import Demonstrator from './demonstrator';
 
 # Instant perception of supplementary content
 

--- a/loader/mdx-parser.tsx
+++ b/loader/mdx-parser.tsx
@@ -1,12 +1,6 @@
 import mdx from '@mdx-js/mdx';
-import toMDXAST from '@mdx-js/mdxast';
 import matter from 'gray-matter';
-import castArray from 'lodash/castArray';
-import React from 'react';
-import parse from 'remark-parse';
 import remarkSlug from 'remark-slug';
-import stringify from 'remark-stringify';
-import unified from 'unified';
 
 // import { readingTime } from 'reading-time-estimator';
 export interface ParserOptions {
@@ -22,100 +16,27 @@ interface ParserProps {
   options: ParserOptions;
 }
 
-// const hasChildren = (node: Node) => {
-//   return !!node.children;
-// };
-
-// const hasChildCodeTag = (node: Node) => {
-//   const { children = [] } = node;
-
-//   const firstChild = (children as Array<Node>)[0];
-
-//   if (hasChildren(node) && firstChild.tagName === 'code') {
-//     return true;
-//   }
-//   return false;
-// };
-
-// const syncCodeBlocks = () => (tree: Parent) => {
-//   tree.children.forEach((child: Node) => {
-//     if (
-//       child.type === 'element' &&
-//       child.tagName === 'pre' &&
-//       child.children &&
-//       child.children[0].tagName === 'code'
-//     ) {
-//       const { properties = {} } = child;
-//       const code = child.children[0];
-//       code.properties = Object.assign(code.properties, properties);
-//     }
-//   });
-// };
-
 export const compile = async (
   src: string,
   options: ParserOptions,
   injectRemarkPlugins: Array<() => (tree: any) => any>,
   injectRehypePlugins: Array<(options: any) => (tree: any) => void>
 ) => {
-  const {
-    // filePath,
-    remarkPlugins,
-    rehypePlugins
-  } = options;
+  const { remarkPlugins, rehypePlugins } = options;
 
   const jsx = await mdx(src, {
-    remarkPlugins: injectRemarkPlugins.concat(remarkPlugins || []).concat([
-      // captureAst
-    ]),
-    rehypePlugins: [
-      // syncAstNodes(ast, filePath)
-    ]
-      .concat(injectRehypePlugins)
-      .concat(rehypePlugins || [])
+    remarkPlugins: [].concat(injectRemarkPlugins).concat(remarkPlugins || []),
+    rehypePlugins: [].concat(injectRehypePlugins).concat(rehypePlugins || [])
   });
   return jsx;
 };
 
 export async function parser(raw: string, options: ParserOptions) {
-  const tree = unified()
-    .use(parse)
-    .use(stringify)
-    .use(stringifier);
-
   const { content, data: meta } = matter(raw);
 
-  const ast = tree.parse(content) as any;
+  const injectRemarkPlugins = [remarkSlug];
+  const injectRehypePlugins = [];
 
-  let mdxast;
-
-  // const captureAst = () => tree => {
-  //   mdxast = tree;
-  //   return tree;
-  // };
-
-  // const captureMeta = () => tree => {
-  //   visit(tree, node => {
-  //     if (node.type === 'code' && node.lang && node.lang.match(/\w+\s.*/)) {
-  //       const parts = node.lang.split(' ')[0];
-  //       node.lang = parts[0];
-  //       node.meta = parts.slice(1).join(' ');
-  //     }
-  //   });
-
-  //   return tree;
-  // };
-
-  const injectRemarkPlugins = [
-    // captureMeta,
-    remarkSlug
-  ];
-  const injectRehypePlugins = [
-    // syncCodeBlocks
-  ];
-
-  const toMdx = (a, o) => toMDXAST(o)(a);
-  const getAst = () => mdxast || toMdx(ast, options);
   const result = await compile(
     content,
     options,
@@ -123,134 +44,19 @@ export async function parser(raw: string, options: ParserOptions) {
     injectRemarkPlugins
   );
 
-  let headingsMap;
-
-  // try {
-  //   headingsMap = ast.children.reduce(
-  //     (memo, node) => {
-  //       if (node.type === 'heading') {
-  //         const string = toString(node);
-  //         const pos = node.position.start.line;
-  //         const slug = kebabCase(string.toLowerCase());
-
-  //         memo.lines[pos] = string;
-  //         memo.headings[string] = memo.lines[string] || [];
-  //         memo.headings[slug] = memo.lines[slug] || [];
-
-  //         memo.headings[string].push(pos);
-  //         memo.headings[slug].push(pos);
-
-  //         return memo;
-  //       }
-  //       return memo;
-  //     },
-  //     {
-  //       lines: {},
-  //       headings: {}
-  //     }
-  //   );
-  // } catch (error) {
-  //   headingsMap = { message: error.message };
-  // }
-
-  const injectLines = castArray(options.injectCode).filter(v => v && v.length);
-
   // const timeToRead = readingTime(raw);
 
   const code = [
     `import React from 'react'`,
     `import { mdx } from '@mdx-js/react'`,
-    !result.match('export const meta') ? 'export const meta = {}' : undefined,
-    `typeof meta !== 'undefined' && Object.assign(meta, ${JSON.stringify(
-      meta
-    )}, meta)`,
-    `export const ast = ${JSON.stringify(mdxast || getAst(), null, 2)}`,
-    `export const raw = ${JSON.stringify(raw)}`,
-    `export const headingsMap = ${JSON.stringify(headingsMap, null, 2)}`,
+    `export const meta = ${JSON.stringify(meta)}`,
+    `export const raw = ${JSON.stringify(content)}`,
     // `export const timeToRead = ${JSON.stringify(timeToRead)}`,
     `export const timeToRead = ''`,
-    ...injectLines,
     result
-  ].filter(Boolean);
+  ].join('\n');
 
-  const response = code.join('\n');
-
-  /*
-  if (options.babel) {
-    const babel = require("@babel/core");
-    const babelConfig =
-      typeof options.babelConfig === "object"
-        ? options.babelConfig
-        : require("./babel-config")(typeof options.babel === "object" ? options.babel : {});
-
-    const transpiled = await new Promise((resolve, reject) => {
-      babel.transform(response, omit(babelConfig, "ignore", "env"), (err, result) => {
-        err ? reject(err) : resolve(result);
-      });
-    });
-
-    response = transpiled;
-  }
-  */
-
-  return { code: response, meta, ast: mdxast, headingsMap, raw };
+  return { code };
 }
-
-function stringifier() {
-  const { Compiler } = this;
-  const { visitors } = Compiler.prototype;
-
-  visitors.jsx = node => node.value;
-  visitors.import = node => node.value;
-  visitors.export = node => node.value;
-}
-
-/*
-function syncAstNodes(withAst, filePath) {
-  const findNode = position =>
-    withAst.children.find(
-      node => node.position && node.position.start.line === position.start.line
-    );
-
-  // const tagWithLineNumber = node => {
-  //   if (!node.position || !node.position.start) {
-  //     return node;
-  //   } else {
-  //     const { properties = {} } = node;
-  //     return Object.assign({}, node, {
-  //       properties: Object.assign({}, properties, {
-  //         "data-line-number": node.position.start.line
-  //       })
-  //     });
-  //   }
-  // };
-
-  return function(options) {
-    return function(tree) {
-      const ast = withAst;
-      // const withLineNumbers = Object.assign({}, tree, {
-      //   children: tree.children.map(tagWithLineNumber).map(node => {
-      //     if (node.position) {
-      //       try {
-      //         const matchingNode = findNode(node.position);
-      //         const parentHeading = findBefore(ast, matchingNode, "heading");
-
-      //         if (parentHeading) {
-      //           node.properties["data-parent-heading"] = parentHeading.position.start.line;
-      //         }
-      //       } catch (error) {
-      //         Logger.error(`Error parsing headings map for markdown file: ${filePath}`);
-      //       }
-      //     }
-
-      //     return node;
-      //   })
-      // });
-
-      // return withLineNumbers;
-    };
-  };
-}
-*/
 
 export default parser;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -56,32 +56,4 @@ class MillipedeApp extends App {
   }
 }
 
-// MillipedeApp.getInitialProps = async ({ Component, ctx }: any): Promise<any> => {
-//   let pageProps = {};
-
-//   if (Component.getInitialProps) {
-//     pageProps = await Component.getInitialProps(ctx);
-//   }
-
-//   return { pageProps };
-// };
-
-// MillipedeApp.getInitialProps = async ({ Component, ctx }) => {
-//   let pageProps = {};
-
-//   if (Component.getInitialProps) {
-//     pageProps = await Component.getInitialProps(ctx);
-//   }
-
-//   // Inject env variables into SSR
-//   // pageProps.CONFIG = getConfig().publicRuntimeConfig.env as AppConfig;
-
-//   // Fetch correct required namespaces depending on route
-//   // pageProps.namespacesRequired = namespaces[router.route];
-
-//   // Logger.log('pageProps.namespacesRequired', pageProps.namespacesRequired);
-
-//   return { pageProps };
-// };
-
 export default appWithTranslation(MillipedeApp);

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -28,7 +28,7 @@
     "/guides/api": "API",
     "/rethink-security": "Sicherheit überdenken",
     "/rethink-security/attackVectors": "Angriffstypen",
-    "/rethink-security/attackVectors/comparison": "Beispiel",
+    "/rethink-security/attackVectors/comparison": "Vergleich",
     "/pidp": "PID/P",
     "/pidp/landing": "Landepunkt",
     "/pidp/approach": "Ansatz",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -28,7 +28,7 @@
     "/guides/api": "API",
     "/rethink-security": "Rethink security",
     "/rethink-security/attackVectors": "Attack vectors",
-    "/rethink-security/attackVectors/comparison": "By example",
+    "/rethink-security/attackVectors/comparison": "Comparison",
     "/pidp": "PID/P",
     "/pidp/landing": "Landing",
     "/pidp/approach": "Approach",

--- a/src/demo/social/components/aspects/ElementComponent.tsx
+++ b/src/demo/social/components/aspects/ElementComponent.tsx
@@ -4,8 +4,8 @@ import React, { useState } from 'react';
 import { WithTranslation } from 'react-i18next';
 
 import { Item } from '../../../../../docs/src/modules/components/common/grid/Item';
-import { Category, CategoryDescriptor, Content, Stack2 } from '../../../../typings/data/import';
 import DotsMobileStepper from '../../../../components/common/stepper/DotsMobileStepper';
+import { Category, CategoryDescriptor, Content, Stack2 } from '../../../../typings/data/import';
 
 export const useStyles = makeStyles((_theme: Theme) =>
   createStyles({
@@ -73,7 +73,6 @@ export const generateGrid = (
                         // icon={data.icon}
                       />
                       <Typography variant='subtitle1' className={classes.title}>
-                        {/* Aufmerksamkeitsspanne */}
                         {t('attention')}
                       </Typography>
                       {element.userFocus && element.userFocus > 0 ? (


### PR DESCRIPTION
Metadata gets extracted from mdx through gray-matter and delivered to the application in result.meta

Replace withRouter HOC through useRouter Hook. Simplify AppWrapper and _app component.

Replace a further utilization of withRouter

Fix translation

Path of component as key

Formatting

Disable highlight option, fix refresh loosing drawer items / fallback if currentPages.length === 0

Frontmatter demo

Remove metadata alike data export, frontmatter gets used for this purpose