### PR TITLE
Make sure the most recent version of next is still compatible with th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.15",
     "mdast-util-toc": "^5.0.2",
     "mui-rte": "^1.14.0",
-    "next": "^9.3.0",
+    "next": "^9.3.1",
     "next-i18next-serverless": "^1.1.180",
     "normalizr": "^3.6.0",
     "polished": "^3.4.4",


### PR DESCRIPTION
…e project, especially with dependency next-i18next-serverless.