### PR TITLE
It seems any browser on iOs can not handle the previous version with …

### DIFF
--- a/docs/src/pages/guides/research/paper/sticky-head-table.tsx
+++ b/docs/src/pages/guides/research/paper/sticky-head-table.tsx
@@ -8,9 +8,11 @@ import TableRow from '@material-ui/core/TableRow';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import LinkIcon from '@material-ui/icons/Link';
+import _ from 'lodash';
 import { TFunction } from 'next-i18next-serverless';
 import Link from 'next/link';
 import React, { useState } from 'react';
+import { isBrowser, isSafari } from 'react-device-detect';
 
 import { useTranslation } from '../../../../../../i18n';
 import { omitAtIndex } from '../../../../modules/utils/collection/array';
@@ -147,11 +149,11 @@ const ExpandableRow = ({
 
 const ns = 'pages/guides/research/paper/index';
 
-const generateContent = (t: TFunction): Array<HeadAndBody> | any => {
-  const rows: Array<HeadAndBody> | string = t('rows', {
+const generateContent = (t: TFunction): Array<HeadAndBody> => {
+  const rows: any = t('rows', {
     returnObjects: true
   });
-  if (rows === 'rows') {
+  if (_.isString(rows) && rows === 'rows') {
     return [];
   }
   return rows;
@@ -185,30 +187,36 @@ export const StickyHeadTable = () => {
           </TableRow>
         </TableHead>
 
-        {rows.map(row => {
-          const { head, body } = row;
-          return (
-            <>
-              <TableHead>
+        <TableBody>
+          {rows.map(row => {
+            const { body, head } = row;
+            return (
+              <>
                 <TableRow>
-                  <TableCell style={{ top: 57 }} colSpan={4}>
+                  <TableCell
+                    variant={'head'}
+                    style={{
+                      top: isBrowser && !isSafari ? 57 : 0
+                    }}
+                    colSpan={4}
+                  >
                     {head}
                   </TableCell>
                 </TableRow>
-              </TableHead>
-              <TableBody>
-                {body.map(row => (
-                  <ExpandableRow
-                    key={row.title}
-                    rowData={row}
-                    columns={columnsReduced}
-                    header={header}
-                  />
-                ))}
-              </TableBody>
-            </>
-          );
-        })}
+                {body.map(row => {
+                  return (
+                    <ExpandableRow
+                      key={row.title}
+                      rowData={row}
+                      columns={columnsReduced}
+                      header={header}
+                    />
+                  );
+                })}
+              </>
+            );
+          })}
+        </TableBody>
       </Table>
     </TableContainer>
   );


### PR DESCRIPTION
…two thead components within a single table component. (The spec allows just one thead but multiple tbody elements). What is unclear is that a desktop-based browser can handle various thead elements in a single table component. For now, a single thead gets used as first head. Headers of type "sticky" which group topics get represented in a table row embedded a tbody element. The variant property with value "head" is required. More investigation is needed here. Also, what is most important is that browsers on iOS, including Simulator, handle top positioning differently, see code.