### PR TITLE
Typescript migration - refactor and bug fixes in the library react-ar…

### DIFF
--- a/docs/src/modules/components/archer/ArcherContainer.tsx
+++ b/docs/src/modules/components/archer/ArcherContainer.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+
+import { ArcherSurface } from './ArcherSurface';
+import { RefProvider } from './context/RefProvider';
+import { TransitionProvider } from './context/TransitionProvider';
+import { ArcherContainerProps } from './types';
+
+export const ArcherContainer: FC<ArcherContainerProps> = ({
+  children,
+  ...rest
+}) => {
+  return (
+    <RefProvider>
+      <TransitionProvider>
+        <ArcherSurface {...rest}>{children}</ArcherSurface>
+      </TransitionProvider>
+    </RefProvider>
+  );
+};

--- a/docs/src/modules/components/archer/ArcherElement.tsx
+++ b/docs/src/modules/components/archer/ArcherElement.tsx
@@ -1,0 +1,56 @@
+import React, { cloneElement, FC, useEffect, useRef } from 'react';
+
+import { useRefDispatch } from './context/RefProvider';
+import { useTransitionDispatch } from './context/TransitionProvider';
+import { ArcherElementProps, Relation, RelationType, SourceToTargetType } from './types';
+
+const generateSourceToTarget = (
+  sourceId: string,
+  relations: Array<Relation>
+): Array<SourceToTargetType> => {
+  return relations.map(
+    ({ targetId, sourceAnchor, targetAnchor, label, style }: RelationType) => ({
+      source: { id: sourceId, anchor: sourceAnchor },
+      target: { id: targetId, anchor: targetAnchor },
+      label,
+      style
+    })
+  );
+};
+
+export const ArcherElement: FC<ArcherElementProps> = ({
+  id,
+  relations,
+  children
+}) => {
+  const refDispatch = useRefDispatch();
+  const transitionDispatch = useTransitionDispatch();
+
+  const elementRef: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    registerTransitions();
+    refDispatch({ type: 'REGISTER', id, ref: elementRef });
+    return () => {
+      refDispatch({ type: 'UNREGISTER', id });
+      transitionDispatch({ type: 'UNREGISTER', elementId: id });
+    };
+  }, []);
+
+  const registerTransitions = () => {
+    const sourceToTargets = generateSourceToTarget(id, relations);
+    transitionDispatch({
+      type: 'REGISTER',
+      elementId: id,
+      sourceToTargets
+    });
+  };
+
+  return cloneElement(children, {
+    ref: elementRef
+  });
+};
+
+ArcherElement.defaultProps = {
+  relations: []
+};

--- a/docs/src/modules/components/archer/ArcherSurface.tsx
+++ b/docs/src/modules/components/archer/ArcherSurface.tsx
@@ -1,0 +1,222 @@
+import React, { FC, ReactNode, RefObject, useRef } from 'react';
+import useResizeObserver from 'use-resize-observer';
+
+import { useRefState } from './context/RefProvider';
+import { useTransitionState } from './context/TransitionProvider';
+import { Point } from './Point';
+import SvgArrow from './SvgArrow';
+import { AnchorPosition, ArcherContainerProps, EntityRelationType, SourceToTargetType } from './types';
+
+const rectToPoint = (rect: ClientRect) => {
+  return new Point(rect.left, rect.top);
+};
+
+const computeCoordinatesFromAnchorPosition = (
+  anchorPosition: AnchorPosition,
+  rect: ClientRect
+) => {
+  switch (anchorPosition) {
+    case 'top':
+      return rectToPoint(rect).add(new Point(rect.width / 2, 0));
+    case 'bottom':
+      return rectToPoint(rect).add(new Point(rect.width / 2, rect.height));
+    case 'left':
+      return rectToPoint(rect).add(new Point(0, rect.height / 2));
+    case 'right':
+      return rectToPoint(rect).add(new Point(rect.width, rect.height / 2));
+    case 'middle':
+      return rectToPoint(rect).add(new Point(rect.width / 2, rect.height / 2));
+    default:
+      return new Point(0, 0);
+  }
+};
+
+const getRectFromRef = (element: HTMLElement): ClientRect => {
+  if (!element) return null;
+
+  return element.getBoundingClientRect();
+};
+
+const getSourceToTargets = (sourceToTargetsMap: {
+  [key: string]: Array<SourceToTargetType>;
+}): Array<SourceToTargetType> => {
+  // Object.values is unavailable in IE11
+  const jaggedSourceToTargets: Array<Array<SourceToTargetType>> = Object.keys(
+    sourceToTargetsMap
+  ).map((key: string) => sourceToTargetsMap[key]);
+  return [].concat(...jaggedSourceToTargets);
+};
+
+const defaultSvgContainerStyle = {
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  top: 0,
+  left: 0,
+  pointerEvents: 'none'
+};
+
+export const ArcherSurface: FC<ArcherContainerProps> = ({
+  arrowLength,
+  arrowThickness,
+  strokeColor,
+  strokeWidth,
+  strokeDasharray,
+  noCurves,
+  style,
+  svgContainerStyle,
+  className,
+  offset,
+  children
+}) => {
+  const parentRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+
+  useResizeObserver({ ref: parentRef });
+
+  const refState = useRefState();
+  const { sourceToTargetsMap } = useTransitionState();
+
+  const arrowMarkerRandomNumber = Math.random().toString().slice(2);
+  const arrowMarkerUniquePrefix = `arrow${arrowMarkerRandomNumber}`;
+
+  const getPointCoordinatesFromAnchorPosition = (
+    position: AnchorPosition,
+    index: string,
+    parentCoordinates: Point
+  ): Point => {
+    const rect = getRectFromRef(refState.refs[index].current);
+
+    if (!rect) {
+      return new Point(0, 0);
+    }
+    const absolutePosition = computeCoordinatesFromAnchorPosition(
+      position,
+      rect
+    );
+
+    return absolutePosition.substract(parentCoordinates);
+  };
+
+  const getParentCoordinates = (): Point => {
+    const rectp = getRectFromRef(parentRef.current);
+
+    if (!rectp) {
+      return new Point(0, 0);
+    }
+    return rectToPoint(rectp);
+  };
+
+  const getMarkerId = (
+    source: EntityRelationType,
+    target: EntityRelationType
+  ): string => {
+    return `${arrowMarkerUniquePrefix}${source.id}${target.id}`;
+  };
+
+  const getSvgContainerStyle = () => ({
+    ...defaultSvgContainerStyle,
+    ...svgContainerStyle
+  });
+
+  const computeArrows = (): ReactNode => {
+    const parentCoordinates = getParentCoordinates();
+
+    return getSourceToTargets(sourceToTargetsMap).map(
+      ({ source, target, label, style = {} }: SourceToTargetType) => {
+        // Actual arrowLength value might be 0, which can't work with a simple 'actualValue || defaultValue'
+        let arrowLengthDetermined = arrowLength;
+        if (style.arrowLength || style.arrowLength === 0) {
+          arrowLengthDetermined = style.arrowLength;
+        }
+
+        const startingAnchorOrientation = source.anchor;
+        const startingPoint = getPointCoordinatesFromAnchorPosition(
+          source.anchor,
+          source.id,
+          parentCoordinates
+        );
+
+        const endingAnchorOrientation = target.anchor;
+        const endingPoint = getPointCoordinatesFromAnchorPosition(
+          target.anchor,
+          target.id,
+          parentCoordinates
+        );
+
+        return (
+          <SvgArrow
+            key={JSON.stringify({ source, target })}
+            startingPoint={startingPoint}
+            startingAnchorOrientation={startingAnchorOrientation}
+            endingPoint={endingPoint}
+            endingAnchorOrientation={endingAnchorOrientation}
+            strokeColor={style.strokeColor || strokeColor}
+            arrowLength={arrowLengthDetermined}
+            strokeWidth={style.strokeWidth || strokeWidth}
+            strokeDasharray={style.strokeDasharray || strokeDasharray}
+            arrowLabel={label}
+            arrowMarkerId={getMarkerId(source, target)}
+            noCurves={style.noCurves || noCurves}
+            offset={offset || 0}
+          />
+        );
+      }
+    );
+  };
+
+  const generateAllArrowMarkers = (): ReactNode => {
+    return getSourceToTargets(sourceToTargetsMap).map(
+      ({ source, target, style = {} }: SourceToTargetType) => {
+        // Actual arrowLength value might be 0, which can't work with a simple 'actualValue || defaultValue'
+        let arrowLengthFinal = arrowLength;
+        if (style.arrowLength || style.arrowLength === 0) {
+          arrowLengthFinal = style.arrowLength;
+        }
+
+        const arrowThicknessFinal = style.arrowThickness || arrowThickness;
+
+        const arrowPath = `M0,0 L0,${arrowThicknessFinal} L${arrowLength},${
+          arrowThicknessFinal / 2
+        } z`;
+
+        return (
+          <marker
+            id={getMarkerId(source, target)}
+            key={getMarkerId(source, target)}
+            markerWidth={arrowLengthFinal}
+            markerHeight={arrowThicknessFinal}
+            refX='0'
+            refY={arrowThicknessFinal / 2}
+            orient='auto'
+            markerUnits='strokeWidth'
+          >
+            <path d={arrowPath} fill={style.strokeColor || strokeColor} />
+          </marker>
+        );
+      }
+    );
+  };
+
+  const SvgArrows = computeArrows();
+
+  return (
+    <div style={{ ...style, position: 'relative' }} className={className}>
+      <div style={{ height: '100%' }} ref={parentRef}>
+        {children}
+      </div>
+
+      <svg style={getSvgContainerStyle() as any}>
+        <defs>{generateAllArrowMarkers()}</defs>
+        {SvgArrows}
+      </svg>
+    </div>
+  );
+};
+
+ArcherSurface.defaultProps = {
+  arrowLength: 10,
+  arrowThickness: 6,
+  strokeColor: '#f00',
+  strokeWidth: 2,
+  svgContainerStyle: {}
+};

--- a/docs/src/modules/components/archer/CustomBoxForward.tsx
+++ b/docs/src/modules/components/archer/CustomBoxForward.tsx
@@ -1,0 +1,59 @@
+import { Box } from '@material-ui/core';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { useRouter } from 'next/router';
+import React, { forwardRef, ForwardRefRenderFunction, ReactNode, useState } from 'react';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    box: {
+      padding: '10px',
+      border: '3px solid black',
+      maxWidth: '100px'
+    },
+    boxHover: {
+      cursor: 'pointer',
+      padding: '10px',
+      border: '3px solid black',
+      maxWidth: '100px',
+      backgroundColor: '#888888'
+    }
+  })
+);
+
+interface CustomBoxProps {
+  id?: string;
+  bgcolor?: string;
+  children: ReactNode;
+}
+
+export const CustomBox: ForwardRefRenderFunction<
+  HTMLDivElement,
+  CustomBoxProps
+> = ({ children, id, bgcolor }, ref) => {
+  const classes = useStyles();
+
+  const router = useRouter();
+  const [selected, setSelected] = useState(false);
+
+  return (
+    <Box
+      bgcolor={bgcolor}
+      className={selected ? classes.boxHover : classes.box}
+      onClick={_e => {
+        router.push(`${router.pathname}#${id}`);
+      }}
+      onMouseEnter={_e => {
+        setSelected(true);
+      }}
+      onMouseLeave={_e => {
+        setSelected(false);
+      }}
+      // Workaround - Box props do not accept a reference prop
+      {...{ ref }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default forwardRef(CustomBox);

--- a/docs/src/modules/components/archer/Point.ts
+++ b/docs/src/modules/components/archer/Point.ts
@@ -1,0 +1,17 @@
+export class Point {
+  x: number;
+  y: number;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+
+  add(point: Point) {
+    return new Point(this.x + point.x, this.y + point.y);
+  }
+
+  substract(point: Point) {
+    return new Point(this.x - point.x, this.y - point.y);
+  }
+}

--- a/docs/src/modules/components/archer/SvgArrow.tsx
+++ b/docs/src/modules/components/archer/SvgArrow.tsx
@@ -1,0 +1,284 @@
+/* eslint-disable no-restricted-globals */
+/* eslint-disable no-param-reassign */
+/* eslint-disable operator-assignment */
+import React, { ReactNode } from 'react';
+
+import { Point } from './Point';
+import { AnchorPosition } from './types';
+
+type Props = {
+  startingPoint: Point;
+  startingAnchorOrientation: AnchorPosition;
+  endingPoint: Point;
+  endingAnchorOrientation: AnchorPosition;
+  strokeColor: string;
+  arrowLength: number;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  arrowLabel?: ReactNode;
+  arrowMarkerId: string;
+  noCurves: boolean;
+  offset?: number;
+};
+
+function computeEndingArrowDirectionVector(endingAnchorOrientation) {
+  switch (endingAnchorOrientation) {
+    case 'left':
+      return { arrowX: -1, arrowY: 0 };
+    case 'right':
+      return { arrowX: 1, arrowY: 0 };
+    case 'top':
+      return { arrowX: 0, arrowY: -1 };
+    case 'bottom':
+      return { arrowX: 0, arrowY: 1 };
+    default:
+      return { arrowX: 0, arrowY: 0 };
+  }
+}
+
+export function computeEndingPointAccordingToArrowHead(
+  xArrowHeadEnd: number,
+  yArrowHeadEnd: number,
+  arrowLength: number,
+  strokeWidth: number,
+  endingAnchorOrientation: AnchorPosition
+) {
+  const endingVector = computeEndingArrowDirectionVector(
+    endingAnchorOrientation
+  );
+
+  const { arrowX, arrowY } = endingVector;
+
+  const xEnd = xArrowHeadEnd + (arrowX * arrowLength * strokeWidth) / 2;
+  const yEnd = yArrowHeadEnd + (arrowY * arrowLength * strokeWidth) / 2;
+
+  return { xEnd, yEnd };
+}
+
+export function computeStartingAnchorPosition(
+  xStart: number,
+  yStart: number,
+  xEnd: number,
+  yEnd: number,
+  startingAnchorOrientation: AnchorPosition
+): { xAnchor1: number; yAnchor1: number } {
+  if (
+    startingAnchorOrientation === 'top' ||
+    startingAnchorOrientation === 'bottom'
+  ) {
+    return {
+      xAnchor1: xStart,
+      yAnchor1: yStart + (yEnd - yStart) / 2
+    };
+  }
+  if (
+    startingAnchorOrientation === 'left' ||
+    startingAnchorOrientation === 'right'
+  ) {
+    return {
+      xAnchor1: xStart + (xEnd - xStart) / 2,
+      yAnchor1: yStart
+    };
+  }
+
+  return { xAnchor1: xStart, yAnchor1: yStart };
+}
+
+export function computeEndingAnchorPosition(
+  xStart: number,
+  yStart: number,
+  xEnd: number,
+  yEnd: number,
+  endingAnchorOrientation: AnchorPosition
+): { xAnchor2: number; yAnchor2: number } {
+  if (
+    endingAnchorOrientation === 'top' ||
+    endingAnchorOrientation === 'bottom'
+  ) {
+    return {
+      xAnchor2: xEnd,
+      yAnchor2: yEnd - (yEnd - yStart) / 2
+    };
+  }
+  if (
+    endingAnchorOrientation === 'left' ||
+    endingAnchorOrientation === 'right'
+  ) {
+    return {
+      xAnchor2: xEnd - (xEnd - xStart) / 2,
+      yAnchor2: yEnd
+    };
+  }
+
+  return { xAnchor2: xEnd, yAnchor2: yEnd };
+}
+
+export function computeLabelDimensions(
+  xStart: number,
+  yStart: number,
+  xEnd: number,
+  yEnd: number
+): { xLabel: number; yLabel: number; labelWidth: number; labelHeight: number } {
+  const labelWidth = Math.max(Math.abs(xEnd - xStart), 1);
+  const labelHeight = Math.max(Math.abs(yEnd - yStart), 1);
+
+  const xLabel = xEnd > xStart ? xStart : xEnd;
+  const yLabel = yEnd > yStart ? yStart : yEnd;
+
+  return {
+    xLabel,
+    yLabel,
+    labelWidth,
+    labelHeight
+  };
+}
+
+function computePathString({
+  xStart,
+  yStart,
+  xAnchor1,
+  yAnchor1,
+  xAnchor2,
+  yAnchor2,
+  xEnd,
+  yEnd,
+  noCurves,
+  offset
+}: {
+  xStart: number;
+  yStart: number;
+  xAnchor1: number;
+  yAnchor1: number;
+  xAnchor2: number;
+  yAnchor2: number;
+  xEnd: number;
+  yEnd: number;
+  noCurves: boolean;
+  offset?: number;
+}): string {
+  const curveMarker = noCurves ? '' : 'C';
+
+  if (offset && offset > 0) {
+    const angle = Math.atan2(yAnchor1 - yStart, xAnchor1 - xStart);
+
+    const xOffset = offset * Math.cos(angle);
+    const yOffset = offset * Math.sin(angle);
+
+    xStart = xStart + xOffset;
+    xEnd = xEnd - xOffset;
+
+    yStart = yStart + yOffset;
+    yEnd = yEnd - yOffset;
+  }
+
+  return (
+    `M${xStart},${yStart} ` +
+    `${curveMarker}${xAnchor1},${yAnchor1} ${xAnchor2},${yAnchor2} ` +
+    `${xEnd},${yEnd}`
+  );
+}
+
+const SvgArrow = ({
+  startingPoint,
+  startingAnchorOrientation,
+  endingPoint,
+  endingAnchorOrientation,
+  strokeColor,
+  arrowLength,
+  strokeWidth,
+  strokeDasharray,
+  arrowLabel,
+  arrowMarkerId,
+  noCurves,
+  offset
+}: Props) => {
+  const actualArrowLength = arrowLength * 2;
+
+  const xStart = startingPoint.x;
+  const yStart = startingPoint.y;
+
+  const endingPointWithArrow = computeEndingPointAccordingToArrowHead(
+    endingPoint.x,
+    endingPoint.y,
+    actualArrowLength,
+    strokeWidth,
+    endingAnchorOrientation
+  );
+  const { xEnd, yEnd } = endingPointWithArrow;
+
+  const startingPosition = computeStartingAnchorPosition(
+    xStart,
+    yStart,
+    xEnd,
+    yEnd,
+    startingAnchorOrientation
+  );
+  const { xAnchor1, yAnchor1 } = startingPosition;
+
+  const endingPosition = computeEndingAnchorPosition(
+    xStart,
+    yStart,
+    xEnd,
+    yEnd,
+    endingAnchorOrientation
+  );
+  const { xAnchor2, yAnchor2 } = endingPosition;
+
+  const pathString = computePathString({
+    xStart,
+    yStart,
+    xAnchor1,
+    yAnchor1,
+    xAnchor2,
+    yAnchor2,
+    xEnd,
+    yEnd,
+    noCurves,
+    offset
+  });
+
+  const { xLabel, yLabel, labelWidth, labelHeight } = computeLabelDimensions(
+    xStart,
+    yStart,
+    xEnd,
+    yEnd
+  );
+
+  return (
+    <g>
+      <path
+        d={pathString}
+        style={{
+          fill: 'none',
+          stroke: strokeColor,
+          strokeWidth,
+          strokeDasharray
+        }}
+        markerEnd={`url(${location.href.split('#')[0]}#${arrowMarkerId})`}
+      />
+      {arrowLabel && (
+        <foreignObject
+          x={xLabel}
+          y={yLabel}
+          width={labelWidth}
+          height={labelHeight}
+          style={{ overflow: 'visible', pointerEvents: 'none' }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              left: '50%',
+              top: '50%',
+              transform: 'translateX(-50%) translateY(-50%)',
+              pointerEvents: 'all'
+            }}
+          >
+            <div>{arrowLabel}</div>
+          </div>
+        </foreignObject>
+      )}
+    </g>
+  );
+};
+
+export default SvgArrow;

--- a/docs/src/modules/components/archer/context/RefProvider.tsx
+++ b/docs/src/modules/components/archer/context/RefProvider.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, Dispatch, useContext, useReducer } from 'react';
+
+import { Action, initialState, reducer, State } from './RefReducer';
+
+const RefStateContext = createContext(null);
+const RefDispatchContext = createContext(null);
+
+export const RefProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <RefStateContext.Provider value={state}>
+      <RefDispatchContext.Provider value={dispatch}>
+        {children}
+      </RefDispatchContext.Provider>
+    </RefStateContext.Provider>
+  );
+};
+
+export const useRefState = () => {
+  const context = useContext<State>(RefStateContext);
+  if (context == null) {
+    throw new Error('useRefState must be used within a RefProvider');
+  }
+  return context;
+};
+
+export const useRefDispatch = () => {
+  const context = useContext<Dispatch<Action>>(RefDispatchContext);
+  if (context == null) {
+    throw new Error('useRefDispatch must be used within a RefProvider');
+  }
+  return context;
+};

--- a/docs/src/modules/components/archer/context/RefReducer.ts
+++ b/docs/src/modules/components/archer/context/RefReducer.ts
@@ -1,0 +1,43 @@
+import { RefObject } from 'react';
+
+export const registerRef = (id: string, ref: RefObject<HTMLElement>) => {
+  return <const>{ type: 'REGISTER', id, ref };
+};
+
+export const unregisterRef = (id: string) => {
+  return <const>{ type: 'UNREGISTER', id };
+};
+
+export type Action = ReturnType<typeof registerRef | typeof unregisterRef>;
+
+export interface State {
+  refs: { [key: string]: RefObject<HTMLElement> };
+}
+
+export const initialState: State = {
+  refs: {}
+};
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'REGISTER':
+      return {
+        ...state,
+        refs: {
+          ...state.refs,
+          [action.id]: action.ref
+        }
+      };
+    case 'UNREGISTER': {
+      const { [action.id]: deleted, ...objectWithoutDeletedProp } = state.refs;
+      return {
+        ...state,
+        refs: {
+          ...objectWithoutDeletedProp
+        }
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/docs/src/modules/components/archer/context/TransitionProvider.tsx
+++ b/docs/src/modules/components/archer/context/TransitionProvider.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, Dispatch, useContext, useReducer } from 'react';
+
+import { Action, initialState, reducer, State } from './TransitionReducer';
+
+const TransitionStateContext = createContext(null);
+const TransitionDispatchContext = createContext(null);
+
+export const TransitionProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <TransitionStateContext.Provider value={state}>
+      <TransitionDispatchContext.Provider value={dispatch}>
+        {children}
+      </TransitionDispatchContext.Provider>
+    </TransitionStateContext.Provider>
+  );
+};
+
+export const useTransitionState = () => {
+  const context = useContext<State>(TransitionStateContext);
+  if (context == null) {
+    throw new Error(
+      'useTransitionState must be used within a TransitionProvider'
+    );
+  }
+  return context;
+};
+
+export const useTransitionDispatch = () => {
+  const context = useContext<Dispatch<Action>>(TransitionDispatchContext);
+  if (context == null) {
+    throw new Error(
+      'useTransitionDispatch must be used within a TransitionProvider'
+    );
+  }
+  return context;
+};

--- a/docs/src/modules/components/archer/context/TransitionReducer.ts
+++ b/docs/src/modules/components/archer/context/TransitionReducer.ts
@@ -1,0 +1,52 @@
+import { SourceToTargetType } from '../types';
+
+export const registerTransitions = (
+  elementId: string,
+  sourceToTargets: Array<SourceToTargetType>
+) => {
+  return <const>{ type: 'REGISTER', elementId, sourceToTargets };
+};
+
+export const unregisterTransitions = (elementId: string) => {
+  return <const>{ type: 'UNREGISTER', elementId };
+};
+
+export type Action = ReturnType<
+  typeof registerTransitions | typeof unregisterTransitions
+>;
+
+export interface State {
+  sourceToTargetsMap: { [key: string]: Array<SourceToTargetType> };
+}
+
+export const initialState = {
+  sourceToTargetsMap: {}
+};
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'REGISTER':
+      return {
+        ...state,
+        sourceToTargetsMap: {
+          ...state.sourceToTargetsMap,
+          [action.elementId]: action.sourceToTargets
+        }
+      };
+    case 'UNREGISTER': {
+      const {
+        [action.elementId]: deleted,
+        ...objectWithoutDeletedProp
+      } = state.sourceToTargetsMap;
+
+      return {
+        ...state,
+        sourceToTargetsMap: {
+          ...objectWithoutDeletedProp
+        }
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/docs/src/modules/components/archer/index.ts
+++ b/docs/src/modules/components/archer/index.ts
@@ -1,0 +1,3 @@
+export { ArcherContainer } from './ArcherContainer';
+export { ArcherSurface } from './ArcherSurface';
+export { ArcherElement } from './ArcherElement';

--- a/docs/src/modules/components/archer/types.ts
+++ b/docs/src/modules/components/archer/types.ts
@@ -1,0 +1,103 @@
+import { ReactElement, ReactNode } from 'react';
+
+export type AnchorPosition = 'top' | 'bottom' | 'left' | 'right' | 'middle';
+
+export interface Relation {
+  targetId: string;
+  targetAnchor: AnchorPosition;
+  sourceAnchor: AnchorPosition;
+  label?: ReactNode;
+  style?: ArrowStyle;
+}
+
+export interface ArrowStyle {
+  strokeColor?: string;
+  strokeWidth?: number;
+  strokeDasharray?: string;
+  arrowLength?: number;
+  arrowThickness?: number;
+  noCurves?: boolean;
+}
+
+export interface ArcherContainerProps {
+  /**
+   * A size in px
+   */
+  arrowLength?: number;
+
+  /**
+   * A size in px
+   */
+  arrowThickness?: number;
+
+  /**
+   * A color string
+   *
+   * @example '#ff0000'
+   */
+  strokeColor?: string;
+
+  /**
+   * A size in px
+   */
+  strokeWidth?: number;
+
+  /**
+   * A string representing an array of sizes
+   * See https://www.w3schools.com/graphics/svg_stroking.asp
+   */
+  strokeDasharray?: string;
+
+  /**
+   * Set this to true if you want angles instead of curves
+   */
+  noCurves?: boolean;
+
+  style?: React.CSSProperties;
+
+  /**
+   * Style of the SVG container element. Useful if you want to add a z-index to your SVG container to draw the arrows under your elements, for example.
+   */
+  svgContainerStyle?: React.CSSProperties;
+
+  className?: string;
+
+  /**
+   * Optional number for space between element and start/end of stroke
+   */
+  offset?: number;
+}
+
+export interface ArcherElementProps {
+  /**
+   * The id that will identify the Archer Element. Should only contain alphanumeric characters and standard characters that you can find in HTML ids.
+   */
+  id: string;
+  relations?: Array<Relation>;
+  style?: React.CSSProperties;
+  // className?: string;
+  // label?: React.ReactNode;
+  children: ReactElement;
+}
+
+// different set of types
+
+export type RelationType = {
+  targetId: string;
+  targetAnchor: AnchorPosition;
+  sourceAnchor: AnchorPosition;
+  label?: ReactNode;
+  style?: ArrowStyle;
+};
+
+export type EntityRelationType = {
+  id: string;
+  anchor: AnchorPosition;
+};
+
+export type SourceToTargetType = {
+  source: EntityRelationType;
+  target: EntityRelationType;
+  label?: ReactNode;
+  style?: ArrowStyle;
+};

--- a/docs/src/pages/perspective/strategy/use.tsx
+++ b/docs/src/pages/perspective/strategy/use.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable import/no-named-as-default */
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 import Hyphenated from 'react-hyphen';
 
 import { useTranslation } from '../../../../../i18n';
-import { CustomBox } from './CustomBox';
+import { ArcherContainer, ArcherElement } from '../../../modules/components/archer';
+import CustomBox from '../../../modules/components/archer/CustomBoxForward';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "typesafe-actions": "^5.1.0",
     "unified": "^9.0.0",
     "unist-util-visit": "^2.0.2",
+    "use-resize-observer": "^6.1.0-alpha.3",
     "uuid": "^8.0.0",
     "vfile": "^4.1.0",
     "victory": "^34.3.0"


### PR DESCRIPTION
…cher

### Bug-Fix

The following commit introduces a breaking change. In the comment of the commit mentioned, children of an Archer-Element must be a single element.

https://github.com/pierpo/react-archer/commit/8430960ac5142b3436d1d50e03365c06485ef814

Taking a closer look at the archer element implementation revealed a misunderstanding of using React's Children.only API.

Children.only(this.props.children);

Children of the following compositions are

***Allowed***

```xml
<div>
	<div>
		<div><div>
	</div>
<div>
```

***Not allowed***

```xml
<>
	<div>
	</div>
	<div>
	</div>
<>
```

=> The use of the API Children.only is entirely useless at this position.

Investing further, the real bug introduced was the passing the onRefUpdate function to child components through cloning a child and set the onRefUpdate to the ref property of the child's component. This change might work for a simple div element, and a reference is made in the comment of the commit ***, but does not work if a child is a separate component***.

Expectation:

Cloning the ref to a child component, which expects a forwarded reference.

Resolution of the problem - Simplify references handling.

1. Create a single reference per an archer element instance

```
const elementRef: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
```

2. Pass the reference to cloneElement

```
cloneElement(children, {ref: elementRef});
```

3. Register the reference, and transitions in componentWillMount lifecycle respectively with useEffect to context

```
refDispatch({ type: 'REGISTER', id, ref: elementRef });
transitionDispatch({type: 'REGISTER', elementId: id, sourceToTargets});
```

=> Remove the reference function entirely

4. Receive and assign the reference received in the custom component (child)

```
export const CustomBox: ForwardRefRenderFunction<HTMLDivElement, CustomBoxProps> = ({ children, id, ... }, ***ref***) => {
...
return (
	<div id={id} ref={ref}
)
};
export default forwardRef(CustomBox);
```

Those changes does not require an unnecessary fake element and allows custom components of various complexity; it makes changes not breaking.

### Refactoring

Migrate sources from javascript to typescript (Done)
Migrate from class-based components to functional components

Persist both references and transitions through a combination of Reacts context and reducer facilities. Use hooks everywhere to communicate with context.

Remove all component state slices of component archer container to context. Create a reference at the top element for the parent.

Mostly untouched is the computation pipeline to generate arrows.

Introduce component ArcherSurface.

The previous code from the archer container was moved here. Archer container gets used to initiate a two-layer context. This ensures the changes are non-breaking from an API perspective.

The user continues to use both the archer container and element.