### PR TITLE
Remove dependency react-archer

### DIFF
--- a/docs/src/pages/ai/general/concept1.tsx
+++ b/docs/src/pages/ai/general/concept1.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
 import { useTranslation } from '../../../../../i18n';
+import { ArcherContainer, ArcherElement } from '../../../modules/components/archer';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/docs/src/pages/ai/general/concept2.tsx
+++ b/docs/src/pages/ai/general/concept2.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
 import { useTranslation } from '../../../../../i18n';
+import { ArcherContainer, ArcherElement } from '../../../modules/components/archer';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/docs/src/pages/ai/general/concept3.tsx
+++ b/docs/src/pages/ai/general/concept3.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
 import { useTranslation } from '../../../../../i18n';
+import { ArcherContainer, ArcherElement } from '../../../modules/components/archer';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/docs/src/pages/ai/general/use.tsx
+++ b/docs/src/pages/ai/general/use.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
 import { useTranslation } from '../../../../../i18n';
+import { ArcherContainer, ArcherElement } from '../../../modules/components/archer';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/docs/src/pages/ai/reverse/hooks/methodHooking.tsx
+++ b/docs/src/pages/ai/reverse/hooks/methodHooking.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
+import { ArcherContainer, ArcherElement } from '../../../../modules/components/archer';
 import { NoteText } from './text';
 
 const useStyles = makeStyles(() =>

--- a/docs/src/pages/ai/reverse/intro/reverseEngineering.tsx
+++ b/docs/src/pages/ai/reverse/intro/reverseEngineering.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, lighten, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { ArcherContainer, ArcherElement } from 'react-archer';
 
 import { useTranslation } from '../../../../../../i18n';
+import { ArcherContainer, ArcherElement } from '../../../../modules/components/archer';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "normalizr": "^3.6.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-archer": "1.5.1",
     "react-device-detect": "^1.12.1",
     "react-dom": "^16.13.1",
     "react-ga": "^2.7.0",


### PR DESCRIPTION
Remove dependency, instead use the less error-prone reimplementation, which is directly available within the project. Ones the project react-archer accepts forthcoming changes, reintegrate the dependency again, and lose the internal implementation.