### PR TITLE
Refactor app-frame integration

### DIFF
--- a/docs/src/modules/components/mdx/MdxDocs.tsx
+++ b/docs/src/modules/components/mdx/MdxDocs.tsx
@@ -5,7 +5,6 @@ import { IReadingTime } from 'reading-time-estimator';
 import AppContent from '../AppContent';
 import AppContentFooter from '../AppContentFooter';
 import AppContentHeader from '../AppContentHeader';
-import AppFrame from '../AppFrame';
 import AppTableOfContents from '../AppTableOfContents';
 import Head from '../Head';
 import { useMdStyles } from '../md/styles/MdStyles';
@@ -44,7 +43,7 @@ const MdxDocs = (props: MarkdownDocsProps) => {
   const classes = useStyles();
 
   return (
-    <AppFrame>
+    <>
       <Head meta={meta} />
       {!disableToc ? <AppTableOfContents content={raw} /> : null}
       <AppContent disableToc={disableToc}>
@@ -61,7 +60,7 @@ const MdxDocs = (props: MarkdownDocsProps) => {
           <AppContentFooter />
         </div>
       </AppContent>
-    </AppFrame>
+    </>
   );
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import App, { AppContext } from 'next/app';
 import React from 'react';
 import ReactGA from 'react-ga';
 
+import AppFrame from '../docs/src/modules/components/AppFrame';
 import AppWrapper from '../docs/src/modules/components/AppWrapper';
 import { loadFAIcons } from '../docs/src/modules/components/icon/FAIconLoader';
 import reducers from '../docs/src/modules/redux/reducers';
@@ -60,7 +61,9 @@ class MillipedeApp extends App<Props> {
     return (
       <HouxProvider reducers={reducers} logDispatchedActions>
         <AppWrapper isMobile={isMobile}>
-          <Component {...pageProps} />
+          <AppFrame>
+            <Component {...pageProps} />
+          </AppFrame>
         </AppWrapper>
       </HouxProvider>
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import { Container, Typography } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 
-import AppFrame from '../docs/src/modules/components/AppFrame';
 import Head from '../docs/src/modules/components/Head';
 import HomeFooter from '../docs/src/modules/components/HomeFooter';
 import { useTranslation } from '../i18n';
@@ -41,26 +40,24 @@ const Index = () => {
   const { t } = useTranslation();
 
   return (
-    <AppFrame>
-      <div className={classes.root}>
-        <Head />
-        <div className={classes.hero}>
-          <Container maxWidth='md' className={classes.content}>
-            <Typography variant='h2' gutterBottom className={classes.title}>
-              {t('application-title')}
-            </Typography>
-            <Typography variant='h4' gutterBottom className={classes.subtitle}>
-              {t('application-subtitle')}
-            </Typography>
+    <div className={classes.root}>
+      <Head />
+      <div className={classes.hero}>
+        <Container maxWidth='md' className={classes.content}>
+          <Typography variant='h2' gutterBottom className={classes.title}>
+            {t('application-title')}
+          </Typography>
+          <Typography variant='h4' gutterBottom className={classes.subtitle}>
+            {t('application-subtitle')}
+          </Typography>
 
-            <TopicsHead />
-            <TopicsDetail />
+          <TopicsHead />
+          <TopicsDetail />
 
-            <HomeFooter />
-          </Container>
-        </div>
+          <HomeFooter />
+        </Container>
       </div>
-    </AppFrame>
+    </div>
   );
 };
 


### PR DESCRIPTION
Integrate app-frame in _app instead of the mdx-docs and index components. The component app-drawer is part of the app-frame component. Before on each page load, a new drawer component got initiated. The state of the drawer was restored based on the current path. Even rendered on the server-side, this causes a flicker effect. Maybe excluding app-drawer from SSR can solve this issue. Further investigation is needed.