### PR TITLE
Update dependency, unpin version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@mdx-js/mdxast": "^1.1.1",
     "@mdx-js/react": "^1.6.4",
     "@sentry/browser": "^5.15.5",
-    "@vangware/window-open-promise": "2.5.0",
+    "@vangware/window-open-promise": "^2.6.0",
     "classnames": "^2.2.6",
     "clsx": "^1.1.0",
     "compose-middleware": "^5.0.1",


### PR DESCRIPTION
A breaking change introduced in version 2.5.0 of window-open-promise got resolved with version 2.6.0.