### PR TITLE
WIP: Rewrite library houx to typescript

### DIFF
--- a/docs/src/modules/redux/houx/index.tsx
+++ b/docs/src/modules/redux/houx/index.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, Dispatch, FC, useContext, useReducer } from 'react';
+import { Action, StateType } from 'typesafe-actions';
+
+interface ContextType {
+  state: StateType<any>;
+  dispatch: Dispatch<Action>;
+}
+
+const Context = createContext<ContextType>({
+  state: {} as any,
+  dispatch: null
+});
+
+const composeReducers = (reducers: ReducerMap) => (state, action) => {
+  const combinedReducers = {};
+  const schemaEntries = Object.entries(reducers);
+  schemaEntries.forEach(e => {
+    const [namespace, reducer] = e;
+    combinedReducers[namespace] = reducer(state && state[namespace], action);
+  });
+  return combinedReducers;
+};
+
+const createStore = (reducers: ReducerMap, logDispatchedActions: boolean) => {
+  const rootReducer = composeReducers(reducers);
+  const initialState = rootReducer(undefined, { type: 'STATE_INIT' });
+  const [state, dispatch] = useReducer(rootReducer, initialState);
+
+  const localDispatch = action => {
+    // enable simple logger
+    if (logDispatchedActions && action.type) {
+      console.info(action);
+    }
+
+    // async actions support
+    if (typeof action === 'function') {
+      return action(localDispatch, state);
+    }
+
+    return dispatch(action);
+  };
+
+  return { state, dispatch: localDispatch };
+};
+
+type ReducerType = (state: any, action: any) => any;
+
+interface ReducerMap {
+  [key: string]: ReducerType;
+}
+
+interface HouxProviderProps {
+  children: React.ReactNode;
+  logDispatchedActions?: boolean;
+  reducers: ReducerMap;
+}
+
+export const HouxProvider: FC<HouxProviderProps> = ({
+  children,
+  reducers,
+  logDispatchedActions
+}) => {
+  const store = createStore(reducers, logDispatchedActions);
+  return <Context.Provider value={store as any}>{children}</Context.Provider>;
+};
+
+HouxProvider.defaultProps = {
+  logDispatchedActions: false
+};
+
+export const useHoux = () => useContext(Context);

--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,10 @@ const configuration = {
 
   target: 'serverless',
 
-  experimental: { modern: true }
+  experimental: {
+    jsconfigPaths: true,
+    modern: true
+  }
 };
 
 module.exports = configuration;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "framer-motion": "^1.11.0",
     "gray-matter": "^4.0.2",
     "group-array": "^1.0.0",
-    "houx": "^1.1.2",
     "immer": "^6.0.9",
     "jss": "^10.1.1",
     "lodash": "^4.17.15",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -59,7 +59,7 @@ class MillipedeApp extends App<Props> {
     const { isMobile } = pageProps;
 
     return (
-      <HouxProvider reducers={reducers} logDispatchedActions>
+      <HouxProvider reducers={reducers}>
         <AppWrapper isMobile={isMobile}>
           <AppFrame>
             <Component {...pageProps} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "paths": {
+      "houx": ["docs/src/modules/redux/houx/index.tsx"]
+    },
     "baseUrl": ".",
     "outDir": "./dist",
     "allowJs": true,


### PR DESCRIPTION
Replace dependency houx with custom typescript rewrite. The library is tiny, a rewrite is possible. Use a nextjs feature called jsconfigPath to use webpack aliases. An alternative with some additional configuration overhead might be the library react-connect-context-hooks.