### PR TITLE
Minimize re-render, shared state through Recoil

### DIFF
--- a/docs/src/markdown/components/head/InteractiveHead.tsx
+++ b/docs/src/markdown/components/head/InteractiveHead.tsx
@@ -1,11 +1,10 @@
 import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
 import LinkIcon from '@material-ui/icons/Link';
 import { useHoux } from 'houx';
-import React, { Dispatch, ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { atom, useRecoilState } from 'recoil';
 
-import { ScrollActions } from '../../../modules/redux/features/actionType';
-import { addScrollNavigation, removeScrollNavigation } from '../../../modules/redux/features/scroll/actions';
 import { RootState } from '../../../modules/redux/reducers';
 
 interface InteraktiveHeadProps {
@@ -39,17 +38,25 @@ export const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+export const selectedElementIdsState = atom<Set<string>>({
+  key: 'selectedElementIds',
+  default: new Set()
+});
+
 const InteraktiveHead = ({ id, variant, children }: InteraktiveHeadProps) => {
   const classes = useStyles();
 
   const {
     state: {
       view: { isMobile }
-    },
-    dispatch
-  }: { state: RootState; dispatch: Dispatch<ScrollActions> } = useHoux();
+    }
+  }: { state: RootState } = useHoux();
 
   const [ref, inView, entry] = useInView();
+
+  const [selectedElements, setSelectedElements] = useRecoilState(
+    selectedElementIdsState
+  );
 
   useEffect(() => {
     if (isMobile) {
@@ -60,10 +67,12 @@ const InteraktiveHead = ({ id, variant, children }: InteraktiveHeadProps) => {
         target: { id: inViewElementId }
       } = entry;
       if (inView) {
-        dispatch(addScrollNavigation(inViewElementId));
+        selectedElements.add(inViewElementId);
+        setSelectedElements(selectedElements);
       }
       if (!inView) {
-        dispatch(removeScrollNavigation(inViewElementId));
+        selectedElements.delete(inViewElementId);
+        setSelectedElements(selectedElements);
       }
     }
   }, [inView, id]);

--- a/docs/src/markdown/components/toc/TocLink.tsx
+++ b/docs/src/markdown/components/toc/TocLink.tsx
@@ -1,10 +1,10 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { useHoux } from 'houx';
 import React, { FC, ReactNode, useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import Link from '../../../modules/components/common/link/Link';
-import { RootState } from '../../../modules/redux/reducers';
+import { selectedElementIdsState } from '../head/InteractiveHead';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -37,15 +37,11 @@ const processLink = (activeState: Set<string>, href: string) => {
 const TocLink: FC<TocLinkProps> = ({ href, children }) => {
   const classes = useStyles();
 
-  const {
-    state: {
-      scroll: { position: activeState }
-    }
-  }: { state: RootState } = useHoux();
+  const selectedElements = useRecoilValue(selectedElementIdsState);
 
-  const isActive = useMemo(() => processLink(activeState, href), [
+  const isActive = useMemo(() => processLink(selectedElements, href), [
     href,
-    activeState.size
+    selectedElements.size
   ]);
 
   return (

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-use-measure": "^2.0.1",
     "react-viewport-utils": "^1.12.1",
     "reading-time-estimator": "1.2.0",
+    "recoil": "0.0.10",
     "remark-parse": "^8.0.2",
     "remark-react": "^7.0.1",
     "remark-slug": "^6.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { enableMapSet } from 'immer';
 import App, { AppContext } from 'next/app';
 import React from 'react';
 import ReactGA from 'react-ga';
+import { RecoilRoot } from 'recoil';
 
 import AppFrame from '../docs/src/modules/components/AppFrame';
 import AppWrapper from '../docs/src/modules/components/AppWrapper';
@@ -60,11 +61,13 @@ class MillipedeApp extends App<Props> {
 
     return (
       <HouxProvider reducers={reducers} logDispatchedActions>
-        <AppWrapper isMobile={isMobile}>
-          <AppFrame>
-            <Component {...pageProps} />
-          </AppFrame>
-        </AppWrapper>
+        <RecoilRoot>
+          <AppWrapper isMobile={isMobile}>
+            <AppFrame>
+              <Component {...pageProps} />
+            </AppFrame>
+          </AppWrapper>
+        </RecoilRoot>
       </HouxProvider>
     );
   }


### PR DESCRIPTION
Do not hoist a state which gets modified at high frequency in react context. The work in this commit reflects an experiment that uses the library Recoil to enables this use case without any re-render of the React tree when a state gets modified.