### PR TITLE
Migrate webpack to V5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "next:start": "next start",
     "app:build": "tsc --project tsconfig.json",
     "loader:build": "tsc --project ./loader/tsconfig.json",
-    "dev": "NODE_ENV=development npm run loader:build && npm run app:build && npm run next:dev",
-    "start": "NODE_ENV=production npm run loader:build && npm run app:build && npm run next:build && npm run next:start",
-    "now-build": "npm run loader:build && npm run app:build && npm run next:build",
+    "dev": "NODE_ENV=development && yarn run loader:build && yarn run app:build && yarn run next:dev",
+    "start": "NODE_ENV=production yarn run loader:build && yarn run app:build && yarn run next:build && yarn run next:start",
+    "now-build": "yarn run loader:build && yarn run app:build && yarn run next:build",
     "clean": "rm -rf dist/ .next/",
     "format:mdx": "prettier --parser mdx --print-width 80 --prose-wrap always --single-quote true --write \"docs/src/pages/**/*.mdx\"",
     "format:md": "prettier --parser markdown --print-width 80 --prose-wrap always --single-quote true --write \"docs/src/pages/**/*.md\"",
@@ -117,15 +117,17 @@
     "eslint-plugin-mdx": "^1.7.1",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
-    "happypack": "^5.0.1",
     "loader-utils": "^2.0.0",
     "nextjs-sitemap-generator": "^1.0.0",
     "prettier": "^2.0.5",
     "raw-loader": "^4.0.1",
     "ts-loader": "^8.0.1",
     "typescript": "^3.9.7",
-    "webpack": "^4.43.0",
+    "webpack": "^5.4.0",
     "webpack-merge": "^5.0.9"
+  },
+  "resolutions": {
+    "webpack": "^5.4.0"
   },
   "engines": {
     "node": "12.x"

--- a/webpack/webpack.dev.conf.js
+++ b/webpack/webpack.dev.conf.js
@@ -4,141 +4,50 @@ const HappyPack = require('happypack');
 
 const pkg = require('../package.json');
 
-const setFs = isServer => {
-  // Fixes npm packages that depend on `fs` module
+const getFallback = isServer => {
   if (!isServer) {
-    return 'empty';
+    return {
+      fs: false
+    };
   }
-  return true;
 };
 
 const webpackConfig = ({ isServer }) => {
+  
   return {
     mode: 'development',
 
-    node: {
-      fs: setFs(isServer)
-    },
-
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json']
+      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+      fallback: {
+        ...getFallback(isServer)
+      }
     },
 
     module: {
       rules: [
         {
           test: /\.(ts|tsx)$/,
-          loader: 'happypack/loader?id=ts'
+          use: [
+            {
+              loader: 'ts-loader',
+              options: {
+                transpileOnly: true
+              },
+            },
+          ],
         },
         {
           test: /\.mdx$/,
-          loader: 'happypack/loader?id=mdx'
-        },
-        {
-          test: /\.md$/,
-          use: 'raw-loader'
-        }
-      ]
-    },
-
-    plugins: [
-      new webpack.DefinePlugin({
-        'process.env': {
-          PROJECT_VERSION: JSON.stringify(pkg.version)
-        }
-      }),
-      new HappyPack({
-        // id declaration references to the loader definition: 'happypack/loader?id=ts'
-        id: 'ts',
-        threads: 3,
-        loaders: [
-          {
-            path: 'ts-loader',
-            query: { happyPackMode: true },
-            options: {
-              // disable type checker - typechecking is handeled by fork-ts-checker-webpack-plugin
-              transpileOnly: true
-            }
-          }
-        ]
-      }),
-      new HappyPack({
-        id: 'mdx',
-        threads: 2,
-        loaders: [
-          {
-            path: 'babel-loader'
-          },
-          {
-            loader: path.join(__dirname, '../dist/loader/mdx-custom-loader')
-          }
-        ]
-      })
-    ]
-  };
-};
-
-module.exports = webpackConfig;
-
-/* webpack.prod.conf in ts */
-
-/*
-import path from 'path';
-import webpack from 'webpack';
-
-import pkg from '../package.json';
-*/
-
-// import * as options from './remarkReactComponents';
-
-/*
-const setFs = isServer => {
-  // Fixes npm packages that depend on `fs` module
-  if (!isServer) {
-    return 'empty';
-  }
-  return true;
-};
-
-// const webpackConfig = ({ isServer }): webpack.Configuration => {
-const webpackConfig = ({ isServer }) => {
-  return {
-    mode: 'production',
-
-    node: {
-      fs: setFs(isServer)
-    },
-
-    // The context is two levels out, because next does currently not support
-    // configurations (next.config) in typescript
-    // context: path.resolve(__dirname, '../../'),
-    // context: path.resolve(__dirname, '../'),
-
-    resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json']
-    },
-
-    module: {
-      rules: [
-        // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
-        { test: /\.tsx?$/, loader: 'ts-loader' },
-        {
-          test: /\.mdx$/,
-          // use: [path.join(__dirname, './loader/mdx-custom-loader')]
           use: [
             {
               loader: 'babel-loader'
             },
             {
-              // loader: path.join(__dirname, './loader/mdx-custom-loader'),
-              loader: path.join(__dirname, '../dist/loader/mdx-custom-loader'),
-              options: {
-                remarkPlugins: [
-                  // options
-                ]
-              }
-            }
-          ]
+              loader: path.join(__dirname, '../dist/loader/mdx-custom-loader')
+            },
+          
+          ],
         },
         {
           test: /\.md$/,
@@ -152,13 +61,10 @@ const webpackConfig = ({ isServer }) => {
         'process.env': {
           PROJECT_VERSION: JSON.stringify(pkg.version)
         }
-      })
+      }),
     ]
+
   };
 };
 
-// const webpackConfig: webpack.Configuration = merge(baseWebpackConfig, webpackDevConfig);
-// export default webpackConfig;
-
-// export default webpackConfig;
-*/
+module.exports = webpackConfig;

--- a/webpack/webpack.prod.conf.js
+++ b/webpack/webpack.prod.conf.js
@@ -3,30 +3,28 @@ const webpack = require('webpack');
 
 const pkg = require('../package.json');
 
-const setFs = isServer => {
-  // Fixes npm packages that depend on `fs` module
+const getFallback = isServer => {
   if (!isServer) {
-    return 'empty';
+    return {
+      fs: false
+    };
   }
-  return true;
 };
 
 const webpackConfig = ({ isServer }) => {
   return {
     mode: 'production',
 
-    node: {
-      fs: setFs(isServer)
-    },
-
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json']
+      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+      fallback: {
+        ...getFallback(isServer)
+      },
     },
 
     module: {
       rules: [
-        // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
-        { test: /\.tsx?$/, loader: 'ts-loader' },
+        { test: /\.(ts|tsx)$/, loader: 'ts-loader' },
         {
           test: /\.mdx$/,
           use: [
@@ -50,7 +48,11 @@ const webpackConfig = ({ isServer }) => {
         'process.env': {
           PROJECT_VERSION: JSON.stringify(pkg.version)
         }
-      })
+      }),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^encoding$/,
+        contextRegExp: /node-fetch/,
+      }),
     ]
   };
 };


### PR DESCRIPTION
From now on, this project uses Yarn in favor of NPM. Increase the dependency version of webpack. Add resolutions section in package.json. The section resolutions get used by Yarn and get ignored by NPM. NPM does not implement selective dependency resolutions for which the field resolutions in package.json is all about.

Next installations also bring its webpack installation in its node-modules folder, V4. Building an application identifies both webpack versions, V5 from an application, and V4 from next. This situation is problematic, similar to when a library serves its own react version in its node-module folder on installation.

Change webpack configurations, according to the webpack V5 documentation. Previous node.something: 'empty' has to be replaced with resolve.fallback.something: false.

Remove concurrent loading strategy through happypack in favor of fast caches of webpack 5.