### PR TITLE
Integrate and refactor the houx library

### DIFF
--- a/docs/src/modules/redux/houx/index.tsx
+++ b/docs/src/modules/redux/houx/index.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, Dispatch, FC, ReactNode, useContext, useReducer } from 'react';
+import { Action, StateType } from 'typesafe-actions';
+
+interface ContextType {
+  state: StateType<any>;
+  dispatch: Dispatch<Action>;
+}
+const Context = createContext<ContextType>({
+  state: {} as any,
+  dispatch: null
+});
+const composeReducers = (reducers: ReducerMap) => (state, action) => {
+  const combinedReducers = {};
+  const schemaEntries = Object.entries(reducers);
+  schemaEntries.forEach(e => {
+    const [namespace, reducer] = e;
+    combinedReducers[namespace] = reducer(state && state[namespace], action);
+  });
+  return combinedReducers;
+};
+const createStore = (reducers: ReducerMap, logDispatchedActions: boolean) => {
+  const rootReducer = composeReducers(reducers);
+  const initialState = rootReducer(undefined, { type: 'STATE_INIT' });
+  const [state, dispatch] = useReducer(rootReducer, initialState);
+  const localDispatch = action => {
+    // enable simple logger
+    if (logDispatchedActions && action.type) {
+      // eslint-disable-next-line no-console
+      console.info(action);
+    }
+    // async actions support
+    if (typeof action === 'function') {
+      return action(localDispatch, state);
+    }
+    return dispatch(action);
+  };
+  return { state, dispatch: localDispatch };
+};
+type ReducerType = (state: any, action: any) => any;
+interface ReducerMap {
+  [key: string]: ReducerType;
+}
+interface HouxProviderProps {
+  children: ReactNode;
+  logDispatchedActions?: boolean;
+  reducers: ReducerMap;
+}
+export const HouxProvider: FC<HouxProviderProps> = ({
+  children,
+  reducers,
+  logDispatchedActions
+}) => {
+  const store = createStore(reducers, logDispatchedActions);
+  return <Context.Provider value={store as any}>{children}</Context.Provider>;
+};
+HouxProvider.defaultProps = {
+  logDispatchedActions: false
+};
+export const useHoux = () => useContext(Context);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "framer-motion": "^2.0.1",
     "gray-matter": "^4.0.2",
     "group-array": "^1.0.0",
-    "houx": "^1.1.2",
     "immer": "^7.0.5",
     "jss": "^10.3.0",
     "lodash": "^4.17.19",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "typeRoots": ["./node_modules/@types"],
-    "lib": ["dom", "dom.iterable", "esnext.array"]
+    "lib": ["dom", "dom.iterable", "esnext.array"],
+    "paths": {
+      "houx": ["docs/src/modules/redux/houx/index.tsx"]
+    }
   },
   "include": [
     "next-env.d.ts",
@@ -36,5 +39,5 @@
     "src/**/*.tsx",
     "webpack/**/*.js"
   ],
-  "exclude": ["node_modules", "loader", "next.config.json"]
+  "exclude": ["node_modules", "loader"]
 }


### PR DESCRIPTION
Integrate the houx library into the project. The project consists of just one tiny file. The original version is not compatible with Reacts upcoming concurrent mode. The library also brings its own react dependency, which is problematic for having two different versions detected. Provide the dependency through NextJs module aliases into the application.