### PR TITLE
Refactor archer comps element, surface, container

### DIFF
--- a/docs/src/modules/components/archer/ArcherContainer.tsx
+++ b/docs/src/modules/components/archer/ArcherContainer.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable import/no-named-as-default */
 import React, { FC } from 'react';
 
-import { ArcherSurface } from './ArcherSurface';
+import { withForwardRef } from '../../../../../src/components/layout/grid/animation/framer/components/with-forward-ref';
+import ArcherSurface from './ArcherSurface';
 import { RefProvider } from './context/RefProvider';
 import { TransitionProvider } from './context/TransitionProvider';
 import { ArcherContainerProps } from './types';
@@ -17,3 +19,7 @@ export const ArcherContainer: FC<ArcherContainerProps> = ({
     </RefProvider>
   );
 };
+
+export default withForwardRef<HTMLElement, ArcherContainerProps>(
+  ArcherContainer
+);

--- a/docs/src/modules/components/archer/CustomBoxForward.tsx
+++ b/docs/src/modules/components/archer/CustomBoxForward.tsx
@@ -1,60 +1,87 @@
-import { Box } from '@material-ui/core';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, makeStyles, Theme } from '@material-ui/core';
+import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import React, {
   forwardRef,
   ForwardRefRenderFunction,
+  MutableRefObject,
   ReactNode,
-  useState
+  useImperativeHandle,
+  useState,
 } from 'react';
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    box: {
-      padding: '10px',
-      border: '3px solid black',
-      maxWidth: '100px'
-    },
-    boxHover: {
-      cursor: 'pointer',
-      padding: '10px',
-      border: '3px solid black',
-      maxWidth: '100px',
-      backgroundColor: '#888888'
-    }
-  })
-);
+export interface StyleProps {
+  bgcolor: string;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>(() => ({
+  box: {
+    padding: '10px',
+    border: '3px solid black',
+    maxWidth: '100px',
+    backgroundColor: props => props.bgcolor
+  },
+  boxHover: {
+    cursor: 'pointer',
+    padding: '10px',
+    border: '3px solid black',
+    maxWidth: '100px',
+    backgroundColor: '#E0E0E0'
+  }
+}));
+
+export interface SelectHandles {
+  select: () => void;
+  unSelect: () => void;
+}
 
 interface CustomBoxProps {
-  id?: string;
-  bgcolor?: string;
   children: ReactNode;
+  routeSegement?: string;
+  bgcolor?: string;
+  dynamicRef?: MutableRefObject<SelectHandles>;
 }
 
 export const CustomBox: ForwardRefRenderFunction<
   HTMLDivElement,
   CustomBoxProps
-> = ({ children, id, bgcolor }, ref) => {
-  const classes = useStyles();
+> = ({ routeSegement, children, bgcolor, dynamicRef }, ref) => {
+  const classes = useStyles({ bgcolor });
 
   const { pathname, push } = useRouter();
   const [selected, setSelected] = useState(false);
 
+  useImperativeHandle(
+    dynamicRef,
+    () => ({
+      select: () => {
+        setSelected(true);
+      },
+      unSelect: () => {
+        setSelected(false);
+      }
+    }),
+    []
+  );
+
   return (
     <Box
-      bgcolor={bgcolor}
-      className={selected ? classes.boxHover : classes.box}
+      className={clsx({
+        [classes.boxHover]: selected,
+        [classes.box]: !selected
+      })}
       onClick={_e => {
-        push(`${pathname}#${id}`);
+        if (routeSegement) {
+          push(`${pathname}#${routeSegement}`);
+        }
       }}
-      onMouseEnter={_e => {
-        setSelected(true);
-      }}
-      onMouseLeave={_e => {
-        setSelected(false);
-      }}
-      // Workaround - Box props do not accept a reference prop
-      {...{ ref }}
+      // onMouseEnter={_e => {
+      //   setSelected(true);
+      // }}
+      // onMouseLeave={_e => {
+      //   setSelected(false);
+      // }}
+      ref={ref}
     >
       {children}
     </Box>

--- a/docs/src/modules/components/archer/context/RefProvider.tsx
+++ b/docs/src/modules/components/archer/context/RefProvider.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
 
-import { Action, initialState, reducer, State } from './RefReducer';
+import { Action, initialState, reducer, RefsState } from './RefReducer';
 
-const RefStateContext = createContext(null);
-const RefDispatchContext = createContext(null);
+const RefStateContext = createContext<RefsState>(null);
+const RefDispatchContext = createContext<Dispatch<Action>>(null);
 
 export const RefProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -18,7 +18,7 @@ export const RefProvider = ({ children }) => {
 };
 
 export const useRefState = () => {
-  const context = useContext<State>(RefStateContext);
+  const context = useContext(RefStateContext);
   if (context == null) {
     throw new Error('useRefState must be used within a RefProvider');
   }
@@ -26,7 +26,7 @@ export const useRefState = () => {
 };
 
 export const useRefDispatch = () => {
-  const context = useContext<Dispatch<Action>>(RefDispatchContext);
+  const context = useContext(RefDispatchContext);
   if (context == null) {
     throw new Error('useRefDispatch must be used within a RefProvider');
   }

--- a/docs/src/modules/components/archer/context/RefReducer.ts
+++ b/docs/src/modules/components/archer/context/RefReducer.ts
@@ -1,7 +1,13 @@
-import { RefObject } from 'react';
+import { MutableRefObject } from 'react';
 
-export const registerRef = (id: string, ref: RefObject<HTMLElement>) => {
-  return <const>{ type: 'REGISTER', id, ref };
+import { SelectHandles } from '../CustomBoxForward';
+
+export const registerRef = (
+  id: string,
+  ref: MutableRefObject<HTMLElement>,
+  dynamicRef: MutableRefObject<SelectHandles>
+) => {
+  return <const>{ type: 'REGISTER', id, ref, dynamicRef };
 };
 
 export const unregisterRef = (id: string) => {
@@ -10,22 +16,30 @@ export const unregisterRef = (id: string) => {
 
 export type Action = ReturnType<typeof registerRef | typeof unregisterRef>;
 
-export interface State {
-  refs: { [key: string]: RefObject<HTMLElement> };
+export interface RefsState {
+  refs: {
+    [key: string]: {
+      ref: MutableRefObject<HTMLElement>;
+      dynamicRef: MutableRefObject<SelectHandles>;
+    };
+  };
 }
 
-export const initialState: State = {
+export const initialState: RefsState = {
   refs: {}
 };
 
-export const reducer = (state: State, action: Action) => {
+export const reducer = (state: RefsState, action: Action) => {
   switch (action.type) {
     case 'REGISTER':
       return {
         ...state,
         refs: {
           ...state.refs,
-          [action.id]: action.ref
+          [action.id]: {
+            ref: action.ref,
+            dynamicRef: action.dynamicRef
+          }
         }
       };
     case 'UNREGISTER': {

--- a/docs/src/modules/components/archer/context/TransitionProvider.tsx
+++ b/docs/src/modules/components/archer/context/TransitionProvider.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
 
-import { Action, initialState, reducer, State } from './TransitionReducer';
+import { Action, initialState, reducer, TransitionsState } from './TransitionReducer';
 
-const TransitionStateContext = createContext(null);
-const TransitionDispatchContext = createContext(null);
+const TransitionStateContext = createContext<TransitionsState>(null);
+const TransitionDispatchContext = createContext<Dispatch<Action>>(null);
 
 export const TransitionProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -18,7 +18,7 @@ export const TransitionProvider = ({ children }) => {
 };
 
 export const useTransitionState = () => {
-  const context = useContext<State>(TransitionStateContext);
+  const context = useContext(TransitionStateContext);
   if (context == null) {
     throw new Error(
       'useTransitionState must be used within a TransitionProvider'
@@ -28,7 +28,7 @@ export const useTransitionState = () => {
 };
 
 export const useTransitionDispatch = () => {
-  const context = useContext<Dispatch<Action>>(TransitionDispatchContext);
+  const context = useContext(TransitionDispatchContext);
   if (context == null) {
     throw new Error(
       'useTransitionDispatch must be used within a TransitionProvider'

--- a/docs/src/modules/components/archer/context/TransitionReducer.ts
+++ b/docs/src/modules/components/archer/context/TransitionReducer.ts
@@ -1,41 +1,41 @@
 import { SourceToTargetType } from '../types';
 
 export const registerTransitions = (
-  elementId: string,
+  id: string,
   sourceToTargets: Array<SourceToTargetType>
 ) => {
-  return <const>{ type: 'REGISTER', elementId, sourceToTargets };
+  return <const>{ type: 'REGISTER', id, sourceToTargets };
 };
 
-export const unregisterTransitions = (elementId: string) => {
-  return <const>{ type: 'UNREGISTER', elementId };
+export const unregisterTransitions = (id: string) => {
+  return <const>{ type: 'UNREGISTER', id };
 };
 
 export type Action = ReturnType<
   typeof registerTransitions | typeof unregisterTransitions
 >;
 
-export interface State {
+export interface TransitionsState {
   sourceToTargetsMap: { [key: string]: Array<SourceToTargetType> };
 }
 
-export const initialState = {
+export const initialState: TransitionsState = {
   sourceToTargetsMap: {}
 };
 
-export const reducer = (state: State, action: Action) => {
+export const reducer = (state: TransitionsState, action: Action) => {
   switch (action.type) {
     case 'REGISTER':
       return {
         ...state,
         sourceToTargetsMap: {
           ...state.sourceToTargetsMap,
-          [action.elementId]: action.sourceToTargets
+          [action.id]: action.sourceToTargets
         }
       };
     case 'UNREGISTER': {
       const {
-        [action.elementId]: deleted,
+        [action.id]: deleted,
         ...objectWithoutDeletedProp
       } = state.sourceToTargetsMap;
 

--- a/docs/src/modules/components/archer/types.tsx
+++ b/docs/src/modules/components/archer/types.tsx
@@ -1,4 +1,6 @@
-import { ReactElement, ReactNode } from 'react';
+import { Component, CSSProperties, MutableRefObject, ReactElement, ReactNode } from 'react';
+
+import { SelectHandles } from './CustomBoxForward';
 
 export type AnchorPosition = 'top' | 'bottom' | 'left' | 'right' | 'middle';
 
@@ -53,12 +55,12 @@ export interface ArcherContainerProps {
    */
   noCurves?: boolean;
 
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 
   /**
    * Style of the SVG container element. Useful if you want to add a z-index to your SVG container to draw the arrows under your elements, for example.
    */
-  svgContainerStyle?: React.CSSProperties;
+  svgContainerStyle?: CSSProperties;
 
   className?: string;
 
@@ -66,7 +68,32 @@ export interface ArcherContainerProps {
    * Optional number for space between element and start/end of stroke
    */
   offset?: number;
+
+  elementStyle?: CSSProperties;
+
+  children?: ReactNode;
 }
+
+export class ArcherContainer extends Component<ArcherContainerProps> {
+  /**
+   * Use this to recompute all the arrow positions. Useful if arrows do not properly rerender
+   * after the viewport or some elements moved.
+   */
+  refreshScreen: () => void;
+}
+
+export type RenderFnSingleParameter = {
+  ref: MutableRefObject<HTMLElement>;
+};
+
+export type RenderSingleFn = ({ ref }: RenderFnSingleParameter) => JSX.Element;
+
+export type RenderFnParameter = {
+  ref: MutableRefObject<HTMLElement>;
+  dynamicRef: MutableRefObject<SelectHandles>;
+};
+
+export type RenderFn = ({ ref, dynamicRef }: RenderFnParameter) => JSX.Element;
 
 export interface ArcherElementProps {
   /**
@@ -74,10 +101,9 @@ export interface ArcherElementProps {
    */
   id: string;
   relations?: Array<Relation>;
-  style?: React.CSSProperties;
-  // className?: string;
-  // label?: React.ReactNode;
-  children: ReactElement;
+  style?: CSSProperties;
+  children?: ReactElement;
+  render?: RenderFn;
 }
 
 // different set of types

--- a/docs/src/pages/perspective/strategy/CustomBox.tsx
+++ b/docs/src/pages/perspective/strategy/CustomBox.tsx
@@ -1,5 +1,4 @@
-import { Box } from '@material-ui/core';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, createStyles, makeStyles } from '@material-ui/core';
 import { useRouter } from 'next/router';
 import React, { FC, ReactNode, useState } from 'react';
 
@@ -15,7 +14,7 @@ const useStyles = makeStyles(() =>
       padding: '10px',
       border: '3px solid black',
       maxWidth: '100px',
-      backgroundColor: '#888888'
+      backgroundColor: '#E0E0E0'
     }
   })
 );

--- a/docs/src/pages/perspective/strategy/use.tsx
+++ b/docs/src/pages/perspective/strategy/use.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-named-as-default */
-import { Box, Typography } from '@material-ui/core';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, createStyles, makeStyles, Typography } from '@material-ui/core';
 import useTranslation from 'next-translate/useTranslation';
 import React from 'react';
 import Hyphenated from 'react-hyphen';
@@ -33,7 +32,7 @@ const useStyles = makeStyles(() =>
       padding: '10px',
       border: '3px solid black',
       maxWidth: '100px',
-      backgroundColor: '#888888'
+      backgroundColor: '#E0E0E0'
     }
   })
 );
@@ -95,7 +94,7 @@ const Diagram = () => {
             }
           ]}
         >
-          <CustomBox id='general' bgcolor='error.main'>
+          <CustomBox bgcolor={'#F44336'}>
             <Typography variant='subtitle1' className={classes.title}>
               <Hyphenated>{`${t('pages/perspective/index:general')} ${t(
                 'pages/perspective/index:problemSolving'
@@ -119,7 +118,7 @@ const Diagram = () => {
             }
           ]}
         >
-          <CustomBox id='realistic' bgcolor='success.main'>
+          <CustomBox bgcolor='#4CAF50'>
             <Typography variant='subtitle1' className={classes.title}>
               <Hyphenated>{`${t('pages/perspective/index:realistic')} ${t(
                 'pages/perspective/index:problemSolving'
@@ -138,7 +137,7 @@ const Diagram = () => {
             }
           ]}
         >
-          <CustomBox id='specific' bgcolor='warning.main'>
+          <CustomBox bgcolor='#FFEB3B'>
             <Typography variant='subtitle1' className={classes.title}>
               <Hyphenated>{`${t('pages/perspective/index:specific')} ${t(
                 'pages/perspective/index:problemSolving'

--- a/src/components/layout/grid/animation/framer/components/with-forward-ref.tsx
+++ b/src/components/layout/grid/animation/framer/components/with-forward-ref.tsx
@@ -1,0 +1,21 @@
+import React, {
+  ComponentType,
+  forwardRef,
+  ForwardRefExoticComponent,
+  ForwardRefRenderFunction,
+  PropsWithoutRef,
+  RefAttributes,
+} from 'react';
+
+export const withForwardRef = <T, P extends Record<string, any>>(
+  Comp: ComponentType<P>
+): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
+  const WrappedComp: ForwardRefRenderFunction<T, P> = (props, ref) => {
+    return <Comp {...props} forwardedRef={ref} />;
+  };
+
+  const name = Comp.displayName || Comp.name;
+  WrappedComp.displayName = `withForwardedRef(${name})`;
+
+  return forwardRef(WrappedComp);
+};


### PR DESCRIPTION
Element: The component allows the passing of a render function (renderFn for now). If a renderFn gets passed, the function gets called gets called with both the ref, and dynamic references. Both references will be available in the component the render function contains in its functional body. If no render function gets passed, the passed component gets cloned, and the references get assigned respectively; see how cloneElement works.
ArcherSurface: Only small stylistic refactoring and null checks applied.
ArcherContainer: Provides two export variants, one standard component, second with forwardRef. To not pollute the function declaration of the component, the functional declaration gets generated with withForwardRef.

Cleanup ref and transition provider, reducer

The refs state contains a new reference called dynamicRef for now of type SelectHandles. The purpose is to instruct the component that lives as a child inside the component archer element.

Improve types

Control customBoxForward from the outside

The major change is the usage of React useImperativeHandle hook, which allows outside control of the component. In the future, this will get replaced by a callback reference, where a reference current is an object of functional references.

Adjust code for usage of comp customBoxForward