### PR TITLE
Onboard flow components not integrated, yet

### DIFF
--- a/docs/src/modules/components/archer/ArcherSurfaceObserver.tsx
+++ b/docs/src/modules/components/archer/ArcherSurfaceObserver.tsx
@@ -1,0 +1,71 @@
+import { EffectRef } from '@huse/effect-ref';
+import { useMergedRef } from '@huse/merged-ref';
+import { cloneElement, FC, ReactElement, useCallback, useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { useMeasure } from '../../../../../src/demo/social/components/reactUseMeasureNextNext';
+import { refContainerScrollFromArcherState } from '../../recoil/features/scroll/timeline/reducer';
+import { RenderSingleFn } from './types';
+
+interface ArcherSurfaceObserverProps {
+  timelineIds: Array<string>;
+  children?: ReactElement;
+  render?: RenderSingleFn;
+}
+export const ArcherSurfaceObserver: FC<ArcherSurfaceObserverProps> = ({
+  timelineIds,
+  children,
+  render
+}) => {
+  const [leftTimelineId, rightTimelineId] = timelineIds;
+
+  const setRefContainerScrollLeftTimeline = useSetRecoilState(
+    refContainerScrollFromArcherState(leftTimelineId)
+  );
+
+  const setRefContainerScrollRightTimeline = useSetRecoilState(
+    refContainerScrollFromArcherState(rightTimelineId)
+  );
+
+  const [containerRef1] = useMeasure({ debounce: 0 });
+  const [containerRef2] = useMeasure({ debounce: 0 });
+
+  const updateRefContainerScrollLeftTimeline = useCallback(
+    (value: EffectRef<HTMLElement>) => {
+      setRefContainerScrollLeftTimeline(state => {
+        return {
+          ...state,
+          refObserved: value
+        };
+      });
+    },
+    [setRefContainerScrollLeftTimeline]
+  );
+
+  const updateRefContainerScrollRightTimeline = useCallback(
+    (value: EffectRef<HTMLElement>) => {
+      setRefContainerScrollRightTimeline(state => {
+        return {
+          ...state,
+          refObserved: value
+        };
+      });
+    },
+    [setRefContainerScrollRightTimeline]
+  );
+
+  useEffect(() => {
+    updateRefContainerScrollLeftTimeline(containerRef1);
+    updateRefContainerScrollRightTimeline(containerRef2);
+  }, []);
+
+  const combinedRefs = useMergedRef([containerRef1, containerRef2]);
+
+  if (render != null) {
+    return render({ ref: combinedRefs as any });
+  }
+
+  return cloneElement(children, {
+    ref: combinedRefs
+  });
+};

--- a/docs/src/modules/recoil/features/scroll/post/reducer.ts
+++ b/docs/src/modules/recoil/features/scroll/post/reducer.ts
@@ -1,6 +1,100 @@
+import { EffectRef } from '@huse/effect-ref';
 import { atomFamily } from 'recoil';
+
+import { CollectionUtil } from '../../../../utils';
 
 export const postIdsState = atomFamily<Array<string>, string>({
   key: 'postIds',
   default: []
 });
+
+export interface RefPostScroll {
+  refObserved: EffectRef<HTMLElement>;
+  refObservedSubSlices: { [key: string]: EffectRef<HTMLElement> };
+}
+
+export type RefPostScrollType = {
+  [value: string]: RefPostScroll;
+};
+
+export const refPostScrollState = atomFamily<RefPostScrollType, string>({
+  key: 'refPostScroll',
+  default: {}
+});
+
+const updateObservedItem = (
+  state: RefPostScrollType,
+  timelineId: string,
+  value: EffectRef<HTMLElement>
+): RefPostScrollType => {
+  return {
+    ...state,
+    [timelineId]: {
+      ...state[timelineId],
+      refObserved: value
+    }
+  };
+};
+
+const removeObservedItem = (
+  state: RefPostScrollType,
+  timelineId: string
+): RefPostScrollType => {
+  const refObservedUpdated = CollectionUtil.Object.removePropertyFromObject(
+    state[timelineId],
+    'refObserved'
+  );
+
+  return {
+    ...state,
+    [timelineId]: {
+      ...refObservedUpdated
+    }
+  };
+};
+
+const updateObservedSubSliceItem = (
+  state: RefPostScrollType,
+  timelineId: string,
+  sliceId: string,
+  value: EffectRef<HTMLElement>
+): RefPostScrollType => {
+  return {
+    ...state,
+    [timelineId]: {
+      ...state[timelineId],
+      refObservedSubSlices: {
+        ...state[timelineId]?.refObservedSubSlices,
+        [sliceId]: value
+      }
+    }
+  };
+};
+
+const removeObservedSubSliceItem = (
+  state: RefPostScrollType,
+  timelineId: string,
+  sliceId: string
+): RefPostScrollType => {
+  const { refObservedSubSlices } = state[timelineId];
+
+  const refObservedSubSlicesUpdated = CollectionUtil.Object.removePropertyFromObject(
+    refObservedSubSlices,
+    sliceId
+  );
+
+  return {
+    ...state,
+    [timelineId]: {
+      ...state[timelineId],
+      refObservedSubSlices: refObservedSubSlicesUpdated
+    }
+  };
+};
+
+export const scrollPostReducer = {
+  updateObservedItem,
+  updateObservedSubSliceItem,
+  removeObservedItem,
+  removeObservedSubSliceItem
+};

--- a/docs/src/modules/recoil/features/scroll/timeline/reducer.ts
+++ b/docs/src/modules/recoil/features/scroll/timeline/reducer.ts
@@ -1,4 +1,10 @@
-import { atom } from 'recoil';
+import { EffectRef } from '@huse/effect-ref';
+import _ from 'lodash';
+import { Translate } from 'next-translate';
+import { atom, atomFamily } from 'recoil';
+
+import { Relation } from '../../../../components/archer/types';
+import { CollectionUtil } from '../../../../utils';
 
 export enum VIEW {
   TIMELINE = 0,
@@ -15,3 +21,246 @@ export const timelineViewState = atom<Views>({
     currentViews: {}
   }
 });
+
+export interface RefContainerScroll {
+  refObserved: EffectRef<HTMLElement>;
+}
+
+export const refContainerScrollState = atomFamily<RefContainerScroll, string>({
+  key: 'refContainerScroll',
+  default: {
+    refObserved: null
+  }
+});
+
+const updateObservedItem = (
+  state: RefContainerScroll,
+  value: EffectRef<HTMLElement>
+): RefContainerScroll => {
+  return {
+    ...state,
+    refObserved: value
+  };
+};
+
+const removeObservedItem = (state: RefContainerScroll): RefContainerScroll => {
+  const refObservedUpdated = CollectionUtil.Object.removePropertyFromObject(
+    state,
+    'refObserved'
+  );
+  return {
+    ...refObservedUpdated
+  };
+};
+
+export const scrollTimelineReducer = {
+  updateObservedItem,
+  removeObservedItem
+};
+
+export const refContainerScrollFromArcherState = atomFamily<
+  RefContainerScroll,
+  string
+>({
+  key: 'refContainerScrollFromArcher',
+  default: {
+    refObserved: null
+  }
+});
+
+// Node and Relation
+// => publish (fixed)>-node-<(fixed) head
+// => publish (fixed)>-relation-<(fixed) head
+
+export const publishActions = ['head', 'upload', 'download', 'tail'];
+export const publishActions2 = ['headB', 'uploadB', 'downloadB', 'tailB'];
+
+export const baseActions = ['head', 'tail'];
+
+type Link = {
+  id: string;
+  nodeValue: string;
+  value: string;
+};
+
+// => publish (fixed)>-node-<(fixed) head
+// => publish (fixed)>-relation-<(fixed) head
+
+export const addTopic = (items: Array<string>, topic: string) => {
+  return items.reduce<Array<Link>>((acc, item) => {
+    acc.push({
+      // id: item,
+      id: `${topic}-nodeId-${item}`,
+      nodeValue: `${topic}-node-${item}`,
+      value: `${topic}-relation-${item}`
+    });
+    return acc;
+  }, []);
+};
+
+export interface Node {
+  id: string;
+  label: string;
+}
+
+export interface NodeWithRelations {
+  relations: Array<Relation>;
+  node: Node;
+}
+
+export interface EdgeConnectionMap {
+  postIds: { [key: string]: string };
+  sliceIds: { [key: string]: string };
+  timelineIds: { [key: string]: string };
+}
+
+export enum LAYOUT {
+  FULL = 0,
+  PROGRESSIVE = 1
+}
+
+export interface NodeWithRelationsWithEdge {
+  nodeWithRelations: Array<NodeWithRelations>;
+  edgeConnections: EdgeConnectionMap;
+  ltr: boolean;
+  layout: LAYOUT;
+}
+
+// TODO: find ideal name
+export interface A {
+  values: Array<NodeWithRelationsWithEdge>;
+  id: string;
+  description: string;
+}
+
+export interface NodesWithRelationsMap {
+  nodesWithRelations: {
+    [key: string]: {
+      values: Array<NodeWithRelationsWithEdge>;
+      id: string;
+      description: string;
+    };
+  };
+  activeId: string;
+  counter: number;
+  finalSize: number;
+}
+
+export const nodesWithRelationsWithEdgeState = atom<NodesWithRelationsMap>({
+  key: 'nodesWithRelationsWithEdge',
+  default: {
+    nodesWithRelations: {},
+    activeId: '',
+    counter: 0,
+    finalSize: 0
+  }
+});
+
+const getEdgeConnections = (
+  item: Link,
+  index: number,
+  length: number,
+  ids: Array<string> | string
+) => {
+  if (_.isArray(ids)) {
+    // Covers scenario - e.g. the progressive scenario has only a single element at the beginning of the animmation sequence
+    if (length === 1) {
+      const [headId] = ids;
+      return {
+        ...(index === 0 && {
+          [item.id]: headId
+        })
+      };
+    }
+    const [headId, tailId] = ids;
+    return {
+      ...(index === 0 && {
+        [item.id]: headId
+      }),
+      ...(index === length - 1 && {
+        [item.id]: tailId
+      })
+    };
+  }
+
+  return {
+    ...((index === 0 || index === length - 1) && {
+      [item.id]: ids
+    })
+  };
+};
+
+export const createNodesWithRelations = (
+  definition: Array<Link>,
+  t: Translate,
+  ltr = true,
+  layout = LAYOUT.FULL
+) => (
+  timelineIds?: Array<string> | string,
+  postIds?: Array<string> | string,
+  sliceIds?: Array<string> | string
+) => {
+  const reduceFn = <T extends NodeWithRelationsWithEdge>(
+    acc: T,
+    link: Link,
+    index: number,
+    links: Array<Link>
+  ): T => {
+    // eslint-disable-next-line no-param-reassign
+    acc = {
+      ...acc,
+      nodeWithRelations: [
+        ...acc.nodeWithRelations,
+        {
+          node: {
+            id: link.id,
+            label: t(link.nodeValue)
+          },
+
+          relations:
+            index !== links.length - 1
+              ? [
+                  {
+                    targetId: `${links[index + 1].id}`,
+                    sourceAnchor: ltr ? 'right' : 'left',
+                    targetAnchor: ltr ? 'left' : 'right',
+                    label: t(link.value)
+                  }
+                ]
+              : []
+        }
+      ],
+      edgeConnections: {
+        ...acc.edgeConnections,
+        timelineIds: {
+          ...acc.edgeConnections.timelineIds,
+          ...getEdgeConnections(link, index, links.length, timelineIds)
+        },
+        postIds: {
+          ...acc.edgeConnections.postIds,
+          ...getEdgeConnections(link, index, links.length, postIds)
+        },
+        sliceIds: {
+          ...acc.edgeConnections.sliceIds,
+          ...getEdgeConnections(link, index, links.length, sliceIds)
+        }
+      }
+    };
+    return acc;
+  };
+
+  const result = ltr
+    ? definition.reduce<NodeWithRelationsWithEdge>(reduceFn, {
+        nodeWithRelations: [],
+        edgeConnections: { postIds: {}, sliceIds: {}, timelineIds: {} },
+        ltr,
+        layout
+      })
+    : definition.reduceRight<NodeWithRelationsWithEdge>(reduceFn, {
+        nodeWithRelations: [],
+        edgeConnections: { postIds: {}, sliceIds: {}, timelineIds: {} },
+        ltr,
+        layout
+      });
+  return result;
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.12",
     "@huse/effect-ref": "^1.0.2",
+    "@huse/merged-ref": "^1.1.1",
     "@material-ui/core": "^5.0.0-alpha.15",
     "@material-ui/icons": "^5.0.0-alpha.15",
     "@material-ui/lab": "^5.0.0-alpha.15",

--- a/src/components/layout/grid/animation/framer/components/Interaction.svc.ts
+++ b/src/components/layout/grid/animation/framer/components/Interaction.svc.ts
@@ -1,0 +1,192 @@
+import _ from 'lodash';
+
+import {
+  LAYOUT,
+  NodesWithRelationsMap,
+  NodeWithRelations,
+  NodeWithRelationsWithEdge,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/timeline/reducer';
+
+export const getSelectedPostIds = (
+  timelineId: string,
+  nodeWithRelationsWithEdgeMap: NodesWithRelationsMap,
+  position: string
+) => {
+  const {
+    activeId,
+    nodesWithRelations,
+    counter,
+    finalSize
+  } = nodeWithRelationsWithEdgeMap;
+
+  const nodeWithRelationsWithEdge = _.get(nodesWithRelations, activeId, {
+    values: [] as Array<NodeWithRelationsWithEdge>
+  });
+
+  const { values } = nodeWithRelationsWithEdge;
+
+  const result = values
+    .map(value => {
+      const {
+        nodeWithRelations,
+        edgeConnections: { timelineIds, postIds },
+        ltr,
+        layout
+      } = value;
+
+      const allNodeIds = nodeWithRelations.map(nodeWithRelation => {
+        const {
+          node: { id }
+        } = nodeWithRelation;
+        return id;
+      });
+
+      if (layout === LAYOUT.PROGRESSIVE) {
+        if (ltr) {
+          if (position === 'left' && counter >= 0) {
+            const relation = allNodeIds[0];
+            if (timelineId === _.get(timelineIds, relation)) {
+              return _.get(postIds, relation);
+            }
+          }
+          if (position === 'right' && counter === finalSize) {
+            const relation = allNodeIds[finalSize - 1];
+            if (timelineId === _.get(timelineIds, relation)) {
+              return _.get(postIds, relation);
+            }
+          }
+        }
+        if (!ltr) {
+          if (position === 'right' && counter >= 0) {
+            const relation = allNodeIds[counter - 1];
+            if (timelineId === _.get(timelineIds, relation)) {
+              return _.get(postIds, relation);
+            }
+          }
+          if (position === 'left' && counter === finalSize) {
+            const relation = allNodeIds[0];
+            if (timelineId === _.get(timelineIds, relation)) {
+              return _.get(postIds, relation);
+            }
+          }
+        }
+      }
+
+      if (layout === LAYOUT.FULL) {
+        const [headRelation] = allNodeIds.slice(0, 1);
+        const [tailRelation] = allNodeIds.slice(-1);
+
+        if (timelineId === _.get(timelineIds, headRelation)) {
+          return _.get(postIds, headRelation);
+        }
+
+        if (timelineId === _.get(timelineIds, tailRelation)) {
+          return _.get(postIds, tailRelation);
+        }
+      }
+
+      return null;
+    })
+    .filter((item, index, list) => {
+      return list.indexOf(item) === index;
+    });
+
+  return result;
+};
+
+export const getSelectedSliceIdsBody = (
+  value: NodeWithRelationsWithEdge,
+  counter: number,
+  finalSize: number
+) => {
+  const { nodeWithRelations, ltr, layout } = value;
+  if (layout === LAYOUT.PROGRESSIVE) {
+    if (ltr) {
+      if (counter > 0) {
+        if (counter < finalSize) {
+          return nodeWithRelations.slice(1, counter);
+        }
+        if (counter === finalSize) {
+          return nodeWithRelations.slice(1, finalSize - 1);
+        }
+      }
+    }
+    if (!ltr) {
+      if (counter > 0) {
+        if (counter < finalSize) {
+          return nodeWithRelations
+            .slice()
+            .reverse()
+            .slice(1, counter)
+            .reverse();
+        }
+        if (counter === finalSize) {
+          return nodeWithRelations.slice(1, finalSize - 1);
+        }
+      }
+    }
+  }
+  if (layout === LAYOUT.FULL) {
+    return nodeWithRelations.slice(1, nodeWithRelations.length - 1);
+  }
+};
+
+export interface SliceMap {
+  postId: string;
+  sliceId: string;
+  nodeWithRelations: NodeWithRelations;
+}
+
+export const getSelectedSliceIds = (
+  timelineId: string,
+  nodeWithRelationsWithEdgeMap: NodesWithRelationsMap
+) => {
+  const { activeId, nodesWithRelations } = nodeWithRelationsWithEdgeMap;
+
+  const nodeWithRelationsWithEdge = _.get(nodesWithRelations, activeId, {
+    values: [] as Array<NodeWithRelationsWithEdge>
+  });
+
+  const { values } = nodeWithRelationsWithEdge;
+
+  const result = values.map<SliceMap>(nodeWithRelationsWithEdge => {
+    const {
+      nodeWithRelations,
+      edgeConnections: { timelineIds, postIds, sliceIds }
+    } = nodeWithRelationsWithEdge;
+
+    const allNodeIds = nodeWithRelations.map(nodeWithRelation => {
+      const {
+        node: { id }
+      } = nodeWithRelation;
+      return id;
+    });
+
+    const [headRelation] = allNodeIds.slice(0, 1);
+    const [tailRelation] = allNodeIds.slice(-1);
+
+    if (timelineId === _.get(timelineIds, headRelation)) {
+      return {
+        postId: _.get(postIds, headRelation),
+        sliceId: _.get(sliceIds, headRelation),
+        nodeWithRelations: nodeWithRelations.find(
+          nodeWithRelation => nodeWithRelation.node.id === headRelation
+        )
+      };
+    }
+
+    if (timelineId === _.get(timelineIds, tailRelation)) {
+      return {
+        postId: _.get(postIds, tailRelation),
+        sliceId: _.get(sliceIds, tailRelation),
+        nodeWithRelations: nodeWithRelations.find(
+          nodeWithRelation => nodeWithRelation.node.id === tailRelation
+        )
+      };
+    }
+
+    return null;
+  });
+
+  return result;
+};

--- a/src/components/layout/grid/animation/framer/components/Interaction.tsx
+++ b/src/components/layout/grid/animation/framer/components/Interaction.tsx
@@ -1,0 +1,86 @@
+import { EffectRef } from '@huse/effect-ref';
+import React, { CSSProperties, FC, useCallback, useLayoutEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import {
+  nodesWithRelationsWithEdgeState,
+  refContainerScrollState,
+  scrollTimelineReducer,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/timeline/reducer';
+import { useMeasure } from '../../../../../../demo/social/components/reactUseMeasureNextNext';
+import { getSelectedPostIds } from './Interaction.svc';
+import { InteractionItem } from './InteractionItem';
+
+export interface InteractionProps {
+  timelineId: string;
+  offSet: number;
+  styles?: CSSProperties;
+  position: string;
+}
+
+export const Interaction: FC<InteractionProps> = ({
+  timelineId,
+  offSet,
+  styles,
+  position
+}) => {
+  const setRefContainerScroll = useSetRecoilState(
+    refContainerScrollState(timelineId)
+  );
+
+  const nodeWithRelationsWithEdge = useRecoilValue(
+    nodesWithRelationsWithEdgeState
+  );
+
+  // TODO: Memoize postIds currently selected
+  const selectedPostIds = getSelectedPostIds(
+    timelineId,
+    nodeWithRelationsWithEdge,
+    position
+  );
+
+  const updateObservedItem = useCallback(
+    (value: EffectRef<HTMLElement>) => {
+      setRefContainerScroll(state =>
+        scrollTimelineReducer.updateObservedItem(state, value)
+      );
+    },
+    [scrollTimelineReducer.updateObservedItem]
+  );
+
+  const removeObservedItem = useCallback(() => {
+    setRefContainerScroll(state =>
+      scrollTimelineReducer.removeObservedItem(state)
+    );
+  }, [scrollTimelineReducer.removeObservedItem]);
+
+  const [containerRef, containerBounds] = useMeasure({ debounce: 0 });
+
+  useLayoutEffect(() => {
+    updateObservedItem(containerRef);
+    return () => {
+      removeObservedItem();
+    };
+  }, []);
+
+  return (
+    <div
+      key={`interaction-${timelineId}`}
+      style={{
+        ...styles
+      }}
+    >
+      {selectedPostIds.map(postId => {
+        return (
+          <InteractionItem
+            key={`interaction-${timelineId}-${postId}`}
+            postId={postId}
+            timelineId={timelineId}
+            containerScroll={containerBounds}
+            offSet={offSet}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/layout/grid/animation/framer/components/InteractionBody.tsx
+++ b/src/components/layout/grid/animation/framer/components/InteractionBody.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable import/no-named-as-default */
+import { createStyles, makeStyles, Typography } from '@material-ui/core';
+import clsx from 'clsx';
+import _ from 'lodash';
+import React, { FC } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { ArcherElement } from '../../../../../../../docs/src/modules/components/archer';
+import CustomBox from '../../../../../../../docs/src/modules/components/archer/CustomBoxForward';
+import {
+  nodesWithRelationsWithEdgeState,
+  NodeWithRelationsWithEdge,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/timeline/reducer';
+import { getSelectedSliceIdsBody } from './Interaction.svc';
+
+interface InteractionBodyProps {}
+
+export const useStyles = makeStyles(() =>
+  createStyles({
+    row: {
+      margin: '100px 0',
+      display: 'flex',
+      justifyContent: 'space-between'
+    },
+    rowSingleElement: {
+      margin: '100px 0',
+      display: 'flex',
+      justifyContent: 'center'
+    }
+  })
+);
+
+export const InteractionBody: FC<InteractionBodyProps> = () => {
+  const classes = useStyles();
+
+  const nodeWithRelationsWithEdgeMap = useRecoilValue(
+    nodesWithRelationsWithEdgeState
+  );
+
+  const {
+    activeId,
+    nodesWithRelations,
+    counter,
+    finalSize
+  } = nodeWithRelationsWithEdgeMap;
+
+  const nodeWithRelationsWithEdge = _.get(nodesWithRelations, activeId, {
+    values: [] as Array<NodeWithRelationsWithEdge>
+  });
+
+  const { values } = nodeWithRelationsWithEdge;
+
+  return (
+    <>
+      {values.map((value, row) => {
+        const nodeWithRelations =
+          getSelectedSliceIdsBody(value, counter, finalSize) || [];
+
+        return (
+          <div
+            key={`row-${row}`}
+            className={clsx({
+              [classes.rowSingleElement]: nodeWithRelations.length === 1,
+              [classes.row]: nodeWithRelations.length >= 2
+            })}
+          >
+            {nodeWithRelations.map(value => {
+              const {
+                node: { id, label },
+                relations
+              } = value;
+              return (
+                <ArcherElement id={id} key={id} relations={relations}>
+                  <CustomBox bgcolor='success.main'>
+                    <Typography variant='subtitle1'>{label}</Typography>
+                  </CustomBox>
+                </ArcherElement>
+              );
+            })}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/layout/grid/animation/framer/components/InteractionFlow.tsx
+++ b/src/components/layout/grid/animation/framer/components/InteractionFlow.tsx
@@ -1,0 +1,81 @@
+import React, { FC } from 'react';
+
+import { ArcherSurface } from '../../../../../../../docs/src/modules/components/archer';
+import { ArcherSurfaceObserver } from '../../../../../../../docs/src/modules/components/archer/ArcherSurfaceObserver';
+import { Interaction } from './Interaction';
+import { InteractionBody } from './InteractionBody';
+
+interface InteractionFlowProps {
+  leftTimelineId: string;
+  rightTimelineId: string;
+  offSetControls: number;
+}
+
+export const InteractionFlow: FC<InteractionFlowProps> = ({
+  leftTimelineId,
+  rightTimelineId,
+  offSetControls
+}) => {
+  return (
+    <ArcherSurfaceObserver
+      timelineIds={[leftTimelineId, rightTimelineId]}
+      render={renderProps => {
+        return (
+          <ArcherSurface
+            noCurves
+            strokeColor='gray'
+            style={{
+              height: '100%',
+              overflow: 'hidden'
+            }}
+            elementStyle={{
+              display: 'flex'
+            }}
+            {...renderProps}
+          >
+            <div
+              style={{
+                width: '15%'
+              }}
+            >
+              <Interaction
+                styles={{
+                  display: 'flex',
+                  justifyContent: 'flex-start'
+                }}
+                timelineId={leftTimelineId}
+                offSet={offSetControls}
+                position='left'
+              />
+            </div>
+            <div
+              style={{
+                width: '70%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center'
+              }}
+            >
+              <InteractionBody />
+            </div>
+            <div
+              style={{
+                width: '15%'
+              }}
+            >
+              <Interaction
+                styles={{
+                  display: 'flex',
+                  justifyContent: 'flex-end'
+                }}
+                timelineId={rightTimelineId}
+                offSet={offSetControls}
+                position='right'
+              />
+            </div>
+          </ArcherSurface>
+        );
+      }}
+    />
+  );
+};

--- a/src/components/layout/grid/animation/framer/components/InteractionItem.tsx
+++ b/src/components/layout/grid/animation/framer/components/InteractionItem.tsx
@@ -1,0 +1,120 @@
+import { EffectRef } from '@huse/effect-ref';
+import React, { FC, useCallback, useLayoutEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import {
+  refPostScrollState,
+  scrollPostReducer,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/post/reducer';
+import {
+  nodesWithRelationsWithEdgeState,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/timeline/reducer';
+import { useMeasure } from '../../../../../../demo/social/components/reactUseMeasureNextNext';
+import { getSelectedSliceIds } from './Interaction.svc';
+import { InteractionSliceObserverWithArcher } from './InteractionSliceObserver';
+import { InteractionItemPropsRoot } from './types';
+
+export const InteractionItem: FC<InteractionItemPropsRoot> = ({
+  containerScroll,
+  timelineId,
+  postId,
+  offSet
+}) => {
+  const setRefPostScroll = useSetRecoilState(refPostScrollState(postId));
+
+  const [postRef, postBounds] = useMeasure({
+    debounce: 0,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    callBack: _node => {}
+  });
+
+  const updateObservedItem = useCallback(
+    (timelineId: string, value: EffectRef<HTMLElement>) => {
+      setRefPostScroll(state =>
+        scrollPostReducer.updateObservedItem(state, timelineId, value)
+      );
+    },
+    [scrollPostReducer.updateObservedItem]
+  );
+
+  const removeObservedItem = useCallback(
+    (timelineId: string) => {
+      setRefPostScroll(state =>
+        scrollPostReducer.removeObservedItem(state, timelineId)
+      );
+    },
+    [scrollPostReducer.removeObservedItem]
+  );
+
+  // 1.1 (mount, and update, deps)
+  useLayoutEffect(() => {
+    updateObservedItem(timelineId, postRef);
+  }, [timelineId, postRef]);
+
+  // 1.2 (unmount)
+  useLayoutEffect(() => {
+    return () => {
+      removeObservedItem(timelineId);
+    };
+  }, []);
+
+  const nodeWithRelationsWithEdge = useRecoilValue(
+    nodesWithRelationsWithEdgeState
+  );
+
+  // TODO: Memoize sliceIds currently selected
+  const selectedSliceIds = getSelectedSliceIds(
+    timelineId,
+    nodeWithRelationsWithEdge
+  );
+
+  const sliceRectangles = selectedSliceIds.map(slice => {
+    const {
+      postId: selectedPostId,
+      sliceId,
+      nodeWithRelations: {
+        relations,
+        node: { id: nodeId }
+      }
+    } = slice || { nodeWithRelations: { node: {} } };
+
+    return selectedPostId && selectedPostId === postId ? (
+      <InteractionSliceObserverWithArcher
+        timelineId={timelineId}
+        postId={postId}
+        sliceId={sliceId}
+        postBounds={postBounds}
+        key={`interaction-item-${timelineId}-${postId}-${sliceId}`}
+        id={nodeId}
+        relations={relations}
+      />
+    ) : null;
+  });
+
+  return (
+    <div
+      style={{
+        top: postBounds.top - containerScroll.top - offSet,
+        height: postBounds.height,
+        position: 'absolute',
+        width: '25px',
+        borderWidth: 'thin',
+        borderStyle: 'solid',
+        display: 'flex',
+        visibility:
+          postBounds.top - containerScroll.top !== 0 ? 'visible' : 'hidden'
+      }}
+    >
+      {sliceRectangles}
+    </div>
+  );
+};
+
+// const InteractionItemWithForwardRef = withForwardRef<
+//   HTMLElement,
+//   InteractionItemProps
+// >(InteractionItem);
+
+// export const InteractionItemWithArcher = withArcher(
+//   InteractionItemWithForwardRef
+// );

--- a/src/components/layout/grid/animation/framer/components/InteractionSliceObserver.tsx
+++ b/src/components/layout/grid/animation/framer/components/InteractionSliceObserver.tsx
@@ -1,0 +1,147 @@
+import { EffectRef } from '@huse/effect-ref';
+import _ from 'lodash';
+import React, { FC, useCallback, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import {
+  refPostScrollState,
+  scrollPostReducer,
+} from '../../../../../../../docs/src/modules/recoil/features/scroll/post/reducer';
+import { useMeasure } from '../../../../../../demo/social/components/reactUseMeasureNextNext';
+import { InteractionSliceProps } from './types';
+import { withArcher } from './with-archer';
+import { withForwardRef } from './with-forward-ref';
+
+// import { useMergedRef } from '@huse/merged-ref';
+const RenderFn = ({ children }) => children();
+
+export const defaultSliceBackgrundColor = {
+  header: {
+    color: '#03a9f4'
+  }, // lightBlue
+  media: { color: '#8bc34a' }, // lightGreen'
+  content: { color: '#4caf50' }, // green
+  sentiment: { color: '#9e9e9e' }, // grey'
+  comments: { color: '#ff5722' } // 'deepOrange'
+};
+
+const InteractionSliceObserver: FC<InteractionSliceProps> = ({
+  timelineId,
+  postId,
+  sliceId,
+  postBounds,
+  forwardedRef,
+  dynamicRef
+}) => {
+  return (
+    <RenderFn key={`renderFn-${timelineId}-${postId}-${sliceId}`}>
+      {() => {
+        const ref = useRef<HTMLElement>();
+
+        const [sliceRef, sliceBounds] = useMeasure({
+          debounce: 0,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          callBack: _node => {
+            ref.current = _node;
+          }
+        });
+
+        // const combinedRef = useMergedRef([sliceRef, forwardedRef]);
+
+        const setRefPostScroll = useSetRecoilState(refPostScrollState(postId));
+
+        const updateItem = useCallback(
+          (
+            timelineId: string,
+            sliceId: string,
+            value: EffectRef<HTMLElement>
+          ) => {
+            setRefPostScroll(state =>
+              scrollPostReducer.updateObservedSubSliceItem(
+                state,
+                timelineId,
+                sliceId,
+                value
+              )
+            );
+          },
+          [scrollPostReducer.updateObservedSubSliceItem, setRefPostScroll]
+        );
+
+        const removeItem = useCallback(
+          (timelineId: string, sliceId: string) => {
+            setRefPostScroll(state =>
+              scrollPostReducer.removeObservedSubSliceItem(
+                state,
+                timelineId,
+                sliceId
+              )
+            );
+          },
+          [scrollPostReducer.removeObservedSubSliceItem, setRefPostScroll]
+        );
+
+        useLayoutEffect(() => {
+          updateItem(timelineId, sliceId, sliceRef);
+          return () => {
+            removeItem(timelineId, sliceId);
+          };
+        }, []);
+
+        const [selected, setSelected] = useState(false);
+
+        useImperativeHandle(
+          dynamicRef,
+          () => ({
+            select: () => {
+              // with List / ListItem / Card
+              ref.current.parentElement.parentElement.scrollIntoView({
+                block: 'center',
+                inline: 'center',
+                behavior: 'smooth'
+              });
+              // with Div / Card
+              // if (ref.current && ref.current.parentElement) {
+              //   ref.current.parentElement.scrollIntoView({
+              //     block: 'center',
+              //     inline: 'center',
+              //     behavior: 'smooth'
+              //   });
+              // }
+              setSelected(true);
+            },
+            unSelect: () => {
+              setSelected(false);
+            }
+          }),
+          [ref.current]
+        );
+
+        return (
+          <div
+            // ref={combinedRef}
+            ref={forwardedRef}
+            style={{
+              top: sliceBounds.top - postBounds.top,
+              height: sliceBounds.height,
+              width: '100%',
+              position: 'absolute',
+              background: !selected
+                ? _.get(defaultSliceBackgrundColor, sliceId).color
+                : '#E0E0E0'
+            }}
+          />
+        );
+      }}
+    </RenderFn>
+  );
+};
+
+const InteractionSliceObserverWithForwardRef = withForwardRef<
+  HTMLElement,
+  InteractionSliceProps
+>(InteractionSliceObserver);
+
+export const InteractionSliceObserverWithArcher = withArcher(
+  InteractionSliceObserverWithForwardRef
+);

--- a/src/components/layout/grid/animation/framer/components/types.tsx
+++ b/src/components/layout/grid/animation/framer/components/types.tsx
@@ -1,0 +1,39 @@
+import { RefObject } from 'react';
+
+import { ArcherElementProps, Relation, RenderFn } from '../../../../../../../docs/src/modules/components/archer/types';
+import { NodeWithRelations } from '../../../../../../../docs/src/modules/recoil/features/scroll/timeline/reducer';
+
+export interface InteractionItemPropsRoot {
+  containerScroll: Partial<DOMRect>;
+  timelineId: string;
+  postId: string;
+  archerData?: NodeWithRelations | Array<NodeWithRelations>;
+  offSet: number;
+  render?: RenderFn;
+}
+
+export interface InteractionItemProps {
+  timelineId: string;
+  postId: string;
+  archerData?: NodeWithRelations | Array<NodeWithRelations>;
+  otherTimelineId?: string;
+  render?: RenderFn;
+}
+
+export type InteractionItemArcherProps = InteractionItemProps &
+  ArcherElementProps;
+
+export interface InteractionSliceProps {
+  timelineId: string;
+  postId: string;
+  sliceId?: string;
+  postBounds?: Partial<DOMRect>;
+  forwardedRef?: RefObject<HTMLDivElement>;
+
+  id?: string;
+  relations?: Array<Relation>;
+  dynamicRef?: any;
+}
+
+export type InteractionSliceArcherProps = InteractionSliceProps &
+  ArcherElementProps;

--- a/src/components/layout/grid/animation/framer/components/with-archer.tsx
+++ b/src/components/layout/grid/animation/framer/components/with-archer.tsx
@@ -1,0 +1,19 @@
+import React, { ComponentType } from 'react';
+
+import { ArcherElement } from '../../../../../../../docs/src/modules/components/archer';
+import { InteractionItemArcherProps, InteractionItemProps, InteractionSliceArcherProps } from './types';
+
+export const withArcher = (Comp: ComponentType<InteractionItemProps>) => {
+  return (props: InteractionItemArcherProps | InteractionSliceArcherProps) => {
+    const { id, relations, ...rest } = props;
+    return (
+      <ArcherElement
+        id={id}
+        relations={relations}
+        render={renderProps => {
+          return <Comp {...renderProps} {...rest} />;
+        }}
+      />
+    );
+  };
+};

--- a/src/demo/social/components/SocialApp.tsx
+++ b/src/demo/social/components/SocialApp.tsx
@@ -74,6 +74,13 @@ export const SocialApp: FC = () => {
           flexDirection: 'column'
         }}
       />
+      {/* {leftTimeline && rightTimeline ? (
+        <InteractionFlow
+          leftTimelineId={leftTimeline.id}
+          rightTimelineId={rightTimeline.id}
+          offSetControls={offSet}
+        />
+      ) : null} */}
       {rightTimelineComp && rightTimelineComp}
     </div>
   );

--- a/src/demo/social/components/reactUseMeasureNextNext.tsx
+++ b/src/demo/social/components/reactUseMeasureNextNext.tsx
@@ -1,0 +1,167 @@
+import { EffectRef, useEffectRef } from '@huse/effect-ref';
+import { debounce as createDebounce } from 'lodash';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type Options = {
+  debounce?: number;
+  callBack?: (node: HTMLElement) => void;
+};
+
+type State = {
+  element: HTMLElement | null;
+  scrollContainers: Array<HTMLElement> | null;
+  lastBounds: Partial<DOMRect>;
+};
+
+const findScrollContainers = (element: HTMLElement): Array<HTMLElement> => {
+  let result: Array<HTMLElement> = [];
+  if (element != null) {
+    const { overflow, overflowX, overflowY } = window.getComputedStyle(element);
+    if (
+      [overflow, overflowX, overflowY].some(
+        prop => prop === 'auto' || prop === 'scroll'
+      )
+    ) {
+      result = [...result, element];
+    }
+    return [...result, ...findScrollContainers(element.parentElement)];
+  }
+  return result;
+};
+
+const keys: Array<keyof DOMRect> = ['top', 'height'];
+
+export const areBoundsEqual = (
+  a: Partial<DOMRect>,
+  b: Partial<DOMRect>
+): boolean => keys.every(key => a[key] === b[key]);
+
+export const useMeasure = ({
+  debounce = 60,
+  callBack
+}: Options): [EffectRef<HTMLElement>, Partial<DOMRect>] => {
+  const [bounds, setBounds] = useState<Partial<DOMRect>>({
+    top: 0,
+    height: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: 0
+  });
+
+  const state = useRef<State>({
+    element: null,
+    scrollContainers: null,
+    lastBounds: bounds
+  });
+
+  const removeListeners = () => {
+    const {
+      current: { scrollContainers }
+    } = state;
+
+    if (scrollContainers != null) {
+      scrollContainers.forEach(scrollContainer => {
+        scrollContainer.removeEventListener('scroll', scrollChange, true);
+      });
+      if (state != null && state.current != null) {
+        state.current.scrollContainers = null;
+      }
+    }
+  };
+
+  const addListeners = () => {
+    const {
+      current: { scrollContainers }
+    } = state;
+
+    if (scrollContainers != null) {
+      scrollContainers.forEach(scrollContainer => {
+        scrollContainer.addEventListener('scroll', scrollChange, {
+          capture: true,
+          passive: true
+        });
+      });
+    }
+  };
+
+  const update = useCallback((node: HTMLElement) => {
+    const {
+      current: { element }
+    } = state;
+
+    if (node != null && node !== element) {
+      if (state != null && state.current != null) {
+        state.current.element = node;
+        state.current.scrollContainers = findScrollContainers(node);
+      }
+      addListeners();
+
+      if (callBack != null) {
+        callBack(node);
+      }
+    }
+    // eslint-disable-next-line consistent-return
+    return () => {
+      removeListeners();
+    };
+  }, []);
+
+  const ref = useEffectRef(update);
+
+  const [scrollChange] = useMemo(() => {
+    const determineBounds = () => {
+      const {
+        current: { element, lastBounds }
+      } = state;
+
+      if (element != null) {
+        const {
+          top,
+          height,
+          bottom,
+          left,
+          right,
+          width,
+          x,
+          y
+        } = element.getBoundingClientRect();
+
+        if (
+          !areBoundsEqual(lastBounds, {
+            top,
+            height,
+            bottom,
+            left,
+            right,
+            width,
+            x,
+            y
+          })
+        ) {
+          setBounds(prevState => ({
+            ...prevState,
+            top,
+            height,
+            bottom,
+            left,
+            right,
+            width,
+            x,
+            y
+          }));
+        }
+      }
+    };
+
+    return [
+      debounce > 0 ? createDebounce(determineBounds, debounce) : determineBounds
+    ];
+  }, [debounce, setBounds]);
+
+  useEffect(() => removeListeners, []);
+
+  return [ref, bounds];
+};


### PR DESCRIPTION
Flow components get used to drawing sequence diagrams between the left and right timeline axes.

Any component included in a timeline, such as a post and its sub-components (media, text, comments, etc.), can be used as the start or endpoint of a sequence.

Basic operations
- Determination of the position of start and endpoints triggered by the scroll movements when user navigation enters the respective timeline. Registration for the event gets initiated in the individual block, so changed position values are immediately available to adjust the flow block position.
- Transfer and assignment of the observer reference to the observed component.