### PR TITLE
Onboard ws mdx compile and runtime

### DIFF
--- a/packages/mdx-compile/package.json
+++ b/packages/mdx-compile/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@app/mdx-compile",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "compile": "tsc",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "@babel/core": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10",
+    "@istok/mdx": "^0.1.1",
+    "@mdx-js/react": "^1.6.22"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/packages/mdx-compile/src/babel-plugin-mdx-browser.ts
+++ b/packages/mdx-compile/src/babel-plugin-mdx-browser.ts
@@ -1,0 +1,46 @@
+import { PluginObj } from '@babel/core';
+import { CallExpression, Identifier } from '@babel/types';
+
+const isCallableExpression = (
+  expression: unknown
+): expression is CallExpression => {
+  return typeof (expression as CallExpression).callee !== 'undefined';
+};
+
+export const BabelPluginMdxBrowser = (): PluginObj => {
+  return {
+    visitor: {
+      // remove all imports, we will add these to scope manually
+      ImportDeclaration(path) {
+        path.remove();
+      },
+      // the `makeShortcode` template is nice for error handling but we
+      // don't need it here as we are manually injecting dependencies
+      VariableDeclaration(path) {
+        // this removes the `makeShortcode` function
+        if (
+          (path.node.declarations[0].id as Identifier).name === 'makeShortcode'
+        ) {
+          path.remove();
+        }
+
+        // this removes any variable that is set using the `makeShortcode` function
+        if (
+          path.node &&
+          path.node.declarations &&
+          path.node.declarations[0] &&
+          path.node.declarations[0].init
+        ) {
+          const expr = path.node.declarations[0].init;
+
+          if (
+            isCallableExpression(expr) &&
+            (expr.callee as Identifier).name === 'makeShortcode'
+          ) {
+            path.remove();
+          }
+        }
+      }
+    }
+  };
+};

--- a/packages/mdx-compile/src/compile.ts
+++ b/packages/mdx-compile/src/compile.ts
@@ -1,0 +1,57 @@
+import { transformAsync } from '@babel/core';
+import presetEnv from '@babel/preset-env';
+import presetReact from '@babel/preset-react';
+import mdx from '@mdx-js/mdx';
+
+import { BabelPluginMdxBrowser } from './babel-plugin-mdx-browser';
+
+type ResourceToUrl = (source: string) => string;
+
+export type BaseCompileOptions = {
+  remarkPlugins: any[];
+  rehypePlugins: any[];
+  compilers: any[];
+};
+
+export type CompileOptions = BaseCompileOptions & {
+  resourceToURL: ResourceToUrl;
+};
+
+export const DEFAULT_COMPILE_OPTIONS: CompileOptions = {
+  resourceToURL: x => x,
+  rehypePlugins: [],
+  remarkPlugins: [],
+  compilers: []
+};
+
+export type CompilationResult = [string, string];
+
+export const compile = async (
+  mdxPlainSource: string,
+  options?: CompileOptions
+): Promise<CompilationResult> => {
+  const { resourceToURL, ...restOptions } = options ?? DEFAULT_COMPILE_OPTIONS;
+
+  const compiledES6CodeFromMdx = await mdx(mdxPlainSource, {
+    ...restOptions,
+    skipExport: true
+  });
+
+  const [serverCode, browserCode] = await Promise.all([
+    transformAsync(compiledES6CodeFromMdx, {
+      presets: [presetReact, presetEnv],
+      configFile: false
+    }),
+    transformAsync(compiledES6CodeFromMdx, {
+      presets: [presetReact, presetEnv],
+      plugins: [BabelPluginMdxBrowser],
+      configFile: false
+    })
+  ]);
+
+  if (!serverCode || !serverCode.code || !browserCode || !browserCode.code) {
+    throw new Error('No code was generated.');
+  }
+
+  return [serverCode.code, browserCode.code];
+};

--- a/packages/mdx-compile/src/index.ts
+++ b/packages/mdx-compile/src/index.ts
@@ -1,0 +1,2 @@
+export { render } from './render';
+export { compile } from './compile';

--- a/packages/mdx-compile/src/render.ts
+++ b/packages/mdx-compile/src/render.ts
@@ -1,0 +1,60 @@
+import { AsyncComponentsLoadConfig, ComponentsMap, createElement, loadComponents, MDXScope } from '@istok/mdx';
+import { ReactElement } from 'react';
+import { renderToString as reactRenderToString } from 'react-dom/server';
+
+import { compile, CompileOptions, DEFAULT_COMPILE_OPTIONS } from './compile';
+
+export interface RenderOptions<S extends MDXScope> {
+  components?: ComponentsMap;
+  asyncComponents?: AsyncComponentsLoadConfig;
+  scope?: S;
+  compileOptions?: CompileOptions;
+  enhanceRoot?(root: ReactElement): ReactElement;
+  renderer?<T = string>(root: ReactElement): T;
+  postRender?(): void;
+}
+
+export const render = async <S extends MDXScope>(
+  mdxPlainSource: string,
+  options: RenderOptions<S> = {
+    compileOptions: DEFAULT_COMPILE_OPTIONS
+  }
+) => {
+  const {
+    asyncComponents,
+    compileOptions = DEFAULT_COMPILE_OPTIONS,
+    scope = {} as S
+  } = options;
+  const {
+    enhanceRoot = root => root,
+    renderer = reactRenderToString
+  } = options;
+  const { postRender = () => void 0 } = options;
+
+  const [serverCode, browserCode] = await compile(
+    mdxPlainSource,
+    compileOptions
+  );
+
+  const loadedAsyncComponents = await loadComponents(asyncComponents);
+  const components = {
+    ...(options.components ?? {}),
+    ...loadedAsyncComponents
+  };
+
+  const element = createElement(serverCode, {
+    scope,
+    components,
+    wrapInProvider: true
+  });
+
+  const contentHtml = renderer(enhanceRoot(element));
+
+  postRender();
+
+  return {
+    compiledSource: browserCode,
+    contentHtml,
+    scope
+  };
+};

--- a/packages/mdx-compile/tsconfig.json
+++ b/packages/mdx-compile/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "target": "ES6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["DOM", "DOM.Iterable", "ESNext.Array"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/mdx-runtime/package.json
+++ b/packages/mdx-runtime/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@app/mdx-runtime",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "compile": "tsc",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "@istok/mdx": "^0.1.1",
+    "@mdx-js/react": "^1.6.22",
+    "react-timing-hooks": "^2.0.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/packages/mdx-runtime/src/index.ts
+++ b/packages/mdx-runtime/src/index.ts
@@ -1,0 +1,1 @@
+export { useMdx } from './use-mdx';

--- a/packages/mdx-runtime/src/use-mdx.ts
+++ b/packages/mdx-runtime/src/use-mdx.ts
@@ -1,0 +1,60 @@
+import { AsyncComponentsLoadConfig, ComponentsMap, createElement, loadComponents, MDXScope } from '@istok/mdx';
+import { MDXProvider } from '@mdx-js/react';
+import { createElement as createElementReact, useCallback, useState } from 'react';
+import { useIdleCallbackEffect } from 'react-timing-hooks';
+
+export interface HydrationParams<S extends MDXScope> {
+  scope?: S;
+  components?: ComponentsMap;
+  asyncComponents?: AsyncComponentsLoadConfig;
+}
+
+const isServer = () => typeof window === 'undefined';
+
+export function useMdx<S extends MDXScope>(
+  compiledSource: string,
+  params: HydrationParams<S>
+) {
+  const { scope = {} as S } = params;
+
+  const [result, setResult] = useState<JSX.Element>();
+
+  // if we're server-side, we can return the raw output early
+  if (isServer()) return result;
+
+  const handle = useCallback(
+    async compiledSource => {
+      const components = {
+        ...(params.components ?? {}),
+        ...(await loadComponents(params.asyncComponents))
+      };
+
+      // wrapping the content with MDXProvider will allow us to customize the standard
+      // markdown components (such as "h1" or "a") with the "components" object
+      const wrappedWithMdxProvider = createElementReact(
+        MDXProvider,
+        {
+          components
+        },
+        createElement(compiledSource, {
+          scope,
+          components,
+          wrapInProvider: false
+        })
+      );
+      setResult(wrappedWithMdxProvider);
+    },
+    [compiledSource]
+  );
+
+  useIdleCallbackEffect(
+    onIdle => {
+      if (compiledSource) {
+        onIdle(async () => await handle(compiledSource));
+      }
+    },
+    [compiledSource]
+  );
+
+  return result;
+}

--- a/packages/mdx-runtime/tsconfig.json
+++ b/packages/mdx-runtime/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "target": "ES6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["DOM", "DOM.Iterable", "ESNext.Array"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
The modules added are similar to a library called next-mdx-remote. The main difference is implementing the logic in typescript and cleaner steps to generate the respective server and client code. The existing loading mechanism gets migrated from a webpack loader to an fs loading approach using dynamic pages in forthcoming commits.