### PR TITLE
Onboard dynamic page loading and utilities

### DIFF
--- a/docs/src/lib/getComponents.tsx
+++ b/docs/src/lib/getComponents.tsx
@@ -1,0 +1,110 @@
+import dynamic from 'next/dynamic';
+import { createElement } from 'react';
+
+const checkForComponentUse = (tagName: string, content: string) => {
+  const exp = new RegExp(`<${tagName}`);
+  return exp.test(content);
+};
+
+// Contains the list of components that can be embed in MDX files
+const components = {
+  Demonstrator: dynamic(() =>
+    import('@demonstrators-social/layout').then(module => module.Demonstrator)
+  ),
+  Tag: dynamic(() => import('@app/components').then(module => module.Tag)),
+  DiagramInterdisciplinaryApproach: dynamic(() =>
+    import('@app/illustrations').then(
+      module => module.Components.DiagramInterdisciplinaryApproach
+    )
+  ),
+  SpectrumOfFalseInformation: dynamic(() =>
+    import('../components/guides/disinformation/general').then(
+      module => module.SpectrumOfFalseInformation
+    )
+  ),
+  Publications: dynamic(() =>
+    import('../components/guides/research/paper').then(
+      module => module.Publications
+    )
+  ),
+  AttackVectorsComparison: dynamic(() =>
+    import('../components/rethink-security/attack-vectors/comparison').then(
+      module => module.AttackVectorsComparison
+    )
+  ),
+  ByExample: dynamic(() =>
+    import('../components/pidp/approach/by-example').then(
+      module => module.ByExample
+    )
+  ),
+  TeamBoard: dynamic(() =>
+    import('../components/discover-more/team').then(module => module.TeamBoard)
+  ),
+  Concept1: dynamic(() =>
+    import('../components/ai/general').then(module => module.Concept1)
+  ),
+  Concept2: dynamic(() =>
+    import('../components/ai/general').then(module => module.Concept2)
+  ),
+  Concept3: dynamic(() =>
+    import('../components/ai/general').then(module => module.Concept3)
+  ),
+  ReverseEngineering: dynamic(() =>
+    import('../components/ai/reverse/intro').then(
+      module => module.ReverseEngineering
+    )
+  ),
+  MethodHooking: dynamic(() =>
+    import('../components/ai/reverse/hooks').then(
+      module => module.MethodHooking
+    )
+  ),
+  DataflowComparison: dynamic(() =>
+    import('../components/pet/dataflow/comparison').then(
+      module => module.DataflowComparison
+    )
+  )
+};
+
+// Returns an array with the components names found in a specific post
+const getHydrationComponentsList = content => {
+  return Object.keys(components).filter(compKey => {
+    return checkForComponentUse(compKey, content);
+  });
+};
+
+// Returns an object with the components required to render a post
+const getComponents = (hydrationComponentsList = []) => {
+  const componentsList = {};
+  hydrationComponentsList.forEach(componentName => {
+    componentsList[componentName] = components[componentName];
+  });
+  return componentsList;
+};
+
+const asyncComponents = {
+  Async: () =>
+    Promise.resolve(({ children }) => createElement('div', {}, children))
+};
+
+const getHydrationAsyncComponentsList = content => {
+  return Object.keys(asyncComponents).filter(compKey => {
+    return checkForComponentUse(compKey, content);
+  });
+};
+
+// Returns an object with the components required to render a blog post
+const getAsyncComponents = (hydrationComponentsList = []) => {
+  const componentsList = {};
+  hydrationComponentsList.forEach(componentName => {
+    componentsList[componentName] = components[componentName];
+  });
+  return componentsList;
+};
+
+export {
+  getComponents,
+  getAsyncComponents,
+  getHydrationComponentsList,
+  getHydrationAsyncComponentsList
+};

--- a/docs/src/lib/getContent.tsx
+++ b/docs/src/lib/getContent.tsx
@@ -1,0 +1,80 @@
+import { render } from '@app/mdx-compile';
+import { Mdx } from '@page/layout';
+import fg from 'fast-glob';
+import fs from 'fs';
+import { isArray } from 'lodash';
+import { GetStaticPropsContext } from 'next';
+import dynamic from 'next/dynamic';
+import path from 'path';
+import remarkSlug from 'remark-slug';
+
+import { getComponents, getHydrationComponentsList } from './getComponents';
+import { getMetadata } from './getMetadata';
+import { getPageDirectory } from './pages';
+
+const h2 = dynamic(() => import('@page/layout').then(module => module.Mdx.h2));
+const h3 = dynamic(() => import('@page/layout').then(module => module.Mdx.h3));
+const h4 = dynamic(() => import('@page/layout').then(module => module.Mdx.h4));
+const h5 = dynamic(() => import('@page/layout').then(module => module.Mdx.h5));
+const h6 = dynamic(() => import('@page/layout').then(module => module.Mdx.h6));
+
+const fsPromises = fs.promises;
+
+export const getContent = async (
+  context: GetStaticPropsContext,
+  pageType: string
+) => {
+  const {
+    params: { slug },
+    locale
+  } = context;
+
+  if (!slug || !locale) {
+    throw new Error(`"slug" and "locale" are required for page props`);
+  }
+
+  const sourceDirectory = getPageDirectory(pageType);
+
+  const pathNoExt = isArray(slug) ? slug.join(path.sep) || '.' : slug;
+
+  const [file] = await fg(`${pathNoExt}/${locale}.{md,mdx}`, {
+    cwd: sourceDirectory
+  });
+
+  const mdFile = path.join(sourceDirectory, file);
+
+  const fileContents = await fsPromises.readFile(mdFile);
+
+  const { metaData, content } = await getMetadata(fileContents);
+
+  const { disableShare, ...restMetaData } = metaData;
+
+  const hydrationComponentsList = getHydrationComponentsList(content);
+
+  const mdxSource = await render(content, {
+    components: {
+      ...getComponents(hydrationComponentsList),
+      h1: Mdx.h1({ disableShare, meta: restMetaData }),
+      h2,
+      h3,
+      h4,
+      h5,
+      h6
+    },
+    compileOptions: {
+      remarkPlugins: [remarkSlug],
+      rehypePlugins: [],
+      compilers: [],
+      resourceToURL(s) {
+        return s;
+      }
+    }
+  });
+
+  return {
+    mdxSource,
+    metaData,
+    hydrationComponentsList,
+    rawContent: content
+  };
+};

--- a/docs/src/lib/getMetadata.ts
+++ b/docs/src/lib/getMetadata.ts
@@ -1,0 +1,22 @@
+import { PageTypes } from '@app/types';
+import matter from 'gray-matter';
+import { readingTime } from 'reading-time-estimator';
+
+export type ContentWithMetadata = {
+  content: string;
+  metaData: PageTypes.MetaData;
+};
+
+export const getMetadata = async (
+  data: Buffer
+): Promise<ContentWithMetadata> => {
+  const { data: metaData, content } = matter(data);
+
+  return {
+    metaData: {
+      ...metaData,
+      timeToRead: readingTime(content)
+    },
+    content
+  };
+};

--- a/docs/src/lib/getPath.ts
+++ b/docs/src/lib/getPath.ts
@@ -1,0 +1,13 @@
+import fg from 'fast-glob';
+
+import { idToPathParams } from './getStaticPathsHelper';
+import { getPageDirectory } from './pages';
+
+export const getPath = async (pageType: string) => {
+  const sourceDirectory = getPageDirectory(pageType);
+
+  const files = await fg(['**/*.{md,mdx}'], { cwd: sourceDirectory });
+
+  const paths = files.map(file => idToPathParams(file));
+  return paths;
+};

--- a/docs/src/lib/getStaticContentProps.tsx
+++ b/docs/src/lib/getStaticContentProps.tsx
@@ -1,0 +1,36 @@
+import { PageTypes } from '@app/types';
+import { GetStaticPropsContext } from 'next';
+
+import { getContent } from './getContent';
+
+export interface GetStaticContentProps {
+  mdxSource: {
+    compiledSource: string;
+    contentHtml: string;
+    scope: any;
+  };
+  hydrationComponentsList: Array<string>;
+  rawContent: string;
+  metaData: PageTypes.MetaData;
+}
+
+interface GetStaticContentPropsOptions {
+  pageType: string;
+  onSuccess: (content: GetStaticContentProps) => void;
+}
+
+export const getStaticContentProps = ({
+  pageType,
+  onSuccess
+}: GetStaticContentPropsOptions) => async (ctx: GetStaticPropsContext) => {
+  const content = await getContent(ctx, pageType);
+
+  if (content && onSuccess) {
+    onSuccess(content);
+  }
+  return {
+    props: {
+      ...content
+    }
+  };
+};

--- a/docs/src/lib/getStaticPathsHelper.ts
+++ b/docs/src/lib/getStaticPathsHelper.ts
@@ -1,0 +1,53 @@
+export type PageParamsField = {
+  slug: Array<string>;
+};
+
+export type PageParams<P extends object = {}, E extends object = {}> = E & {
+  params: PageParamsField & P;
+};
+
+export type IdToParams<P extends PageParams> = (id: string) => P;
+export type ParamsToId<P extends PageParams> = (params: P) => string;
+
+export type LocalizedBPageParams = PageParams<
+  {},
+  {
+    locale: string;
+  }
+>;
+
+export const paramsToId = (extension: string) => ({
+  params,
+  locale
+}: LocalizedBPageParams): string => {
+  return params.slug.join('/') + '/' + locale + extension;
+};
+
+export const idToLocale = (id: string) => {
+  const parts = id.split('/');
+  const [locale] = parts[parts.length - 1].split('.');
+
+  if (!locale) {
+    throw new Error(`Failed to determine locale of page "${id}".`);
+  }
+
+  return locale;
+};
+
+export const idToSlug = (id: string) => {
+  const slug = id.split('/').slice(0, -1);
+  if (slug.length === 0) {
+    throw new Error(`Failed to determine slug of page "${id}".`);
+  }
+
+  return slug;
+};
+
+export const idToPathParams: IdToParams<LocalizedBPageParams> = id => {
+  return {
+    params: {
+      slug: idToSlug(id)
+    },
+    locale: idToLocale(id)
+  };
+};

--- a/docs/src/lib/getStaticTranslationProps.tsx
+++ b/docs/src/lib/getStaticTranslationProps.tsx
@@ -1,0 +1,42 @@
+import { isArray } from 'lodash';
+import { GetStaticPropsContext } from 'next';
+import loadNamespaces from 'next-translate/loadNamespaces';
+import path from 'path';
+
+export interface GetStaticTranslationProps {
+  __lang?: string;
+  __namespaces?: { [key: string]: object };
+}
+
+interface GetStaticTranslationPropsOptions {
+  onSuccess: (namespaces: GetStaticTranslationProps) => void;
+}
+
+export const getStaticTranslationProps = ({
+  onSuccess
+}: GetStaticTranslationPropsOptions) => async (ctx: GetStaticPropsContext) => {
+  const {
+    params: { slug },
+    locale
+  } = ctx;
+
+  if (!slug || !locale) {
+    throw new Error(`"slug" and "locale" are required for page props`);
+  }
+
+  const pathNoExt = isArray(slug) ? slug.join(path.sep) || '.' : slug;
+
+  const namespaces = await loadNamespaces({
+    ...ctx,
+    pathname: `/${pathNoExt}`
+  });
+  if (namespaces && onSuccess) {
+    onSuccess(namespaces);
+  }
+
+  return {
+    props: {
+      ...namespaces
+    }
+  };
+};

--- a/docs/src/lib/pages.ts
+++ b/docs/src/lib/pages.ts
@@ -1,0 +1,10 @@
+import { get } from 'lodash';
+import path from 'path';
+
+export const sourceDirectories = {
+  docs: 'docs/src/pages'
+};
+
+export const getPageDirectory = (pageType: string) => {
+  return path.resolve(process.cwd(), get(sourceDirectories, pageType));
+};

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -1,0 +1,79 @@
+import { useMdx } from '@app/mdx-runtime';
+import { Mdx } from '@page/layout';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { mergeProps } from 'next-merge-props';
+import dynamic from 'next/dynamic';
+import React, { FC } from 'react';
+
+import { getComponents } from '../../docs/src/lib/getComponents';
+import { getPath } from '../../docs/src/lib/getPath';
+import { GetStaticContentProps, getStaticContentProps } from '../../docs/src/lib/getStaticContentProps';
+import { GetStaticTranslationProps, getStaticTranslationProps } from '../../docs/src/lib/getStaticTranslationProps';
+
+const h2 = dynamic(() => import('@page/layout').then(module => module.Mdx.h2));
+const h3 = dynamic(() => import('@page/layout').then(module => module.Mdx.h3));
+const h4 = dynamic(() => import('@page/layout').then(module => module.Mdx.h4));
+const h5 = dynamic(() => import('@page/layout').then(module => module.Mdx.h5));
+const h6 = dynamic(() => import('@page/layout').then(module => module.Mdx.h6));
+
+type DynamicPageProps = GetStaticTranslationProps & GetStaticContentProps;
+
+const DynamicPage: FC<DynamicPageProps> = ({
+  mdxSource,
+  metaData,
+  hydrationComponentsList,
+  rawContent
+}) => {
+  const { compiledSource, scope } = mdxSource;
+
+  const { disableShare, ...restMetaData } = metaData;
+
+  const content = useMdx(compiledSource, {
+    components: {
+      ...getComponents(hydrationComponentsList),
+      h1: Mdx.h1({ disableShare, meta: restMetaData }),
+      h2,
+      h3,
+      h4,
+      h5,
+      h6
+    },
+    scope
+  });
+
+  return (
+    <Mdx.MdxDocs meta={restMetaData} raw={rawContent}>
+      {content}
+    </Mdx.MdxDocs>
+  );
+};
+
+export const getStaticProps: GetStaticProps = mergeProps(
+  [
+    getStaticTranslationProps({
+      onSuccess: _props => {
+        // console.log('static translation props', props);
+      }
+    }),
+    getStaticContentProps({
+      pageType: 'docs',
+      onSuccess: _props => {
+        // console.log('static content props', props);
+      }
+    })
+  ],
+  {
+    resolutionType: 'parallel',
+    debug: true
+  }
+);
+
+export const getStaticPaths: GetStaticPaths = async function getStaticPaths() {
+  const paths = await getPath('docs');
+  return {
+    paths,
+    fallback: false
+  };
+};
+
+export default DynamicPage;


### PR DESCRIPTION
The main entry point for document pages is the file named [...slug.tsx]. This array representation allows page constellations of any depth. Available pages get prepared through static getPath and getProps methods.
- GetStaticPath determines the path of a page available.
- GetStaticProps both pre-renders content and loads respective translation for a distinct locale.