### PR TITLE
Page refresh triggers focus of all page elements

### DIFF
--- a/packages/page/layout/src/components/AppContent.tsx
+++ b/packages/page/layout/src/components/AppContent.tsx
@@ -34,7 +34,6 @@ export const AppContent: FC<AppContentProps> = ({ children, disableToc }) => {
     <Container
       component='main'
       id='main-content'
-      tabIndex={-1}
       className={clsx(classes.root, {
         [classes.disableToc]: disableToc
       })}

--- a/packages/page/layout/src/mdx/MdxElement.tsx
+++ b/packages/page/layout/src/mdx/MdxElement.tsx
@@ -25,7 +25,8 @@ export const useStyles = makeStyles(() =>
   createStyles({
     headerRow: {
       display: 'flex',
-      flexDirection: 'row'
+      flexDirection: 'row',
+      marginTop: '56px'
     }
   })
 );


### PR DESCRIPTION
- Removing appContents tabIndex seems to resolve the problem.
- Specify explicit marginTop on h1 component