### PR TITLE
Introduce property isInteractive on ArcherElement

### DIFF
--- a/packages/app/components/src/archer/ArcherElement.tsx
+++ b/packages/app/components/src/archer/ArcherElement.tsx
@@ -31,13 +31,15 @@ export interface ArcherElementProps {
   style?: CSSProperties;
   children?: ReactElement;
   render?: RenderFn;
+  isInteractive?: boolean;
 }
 
 export const ArcherElement: FC<ArcherElementProps> = ({
   id,
   relations = [],
   children,
-  render
+  render,
+  isInteractive = false
 }) => {
   const refDispatch = useRefDispatch();
   const transitionDispatch = useTransitionDispatch();
@@ -59,10 +61,18 @@ export const ArcherElement: FC<ArcherElementProps> = ({
   }, []);
 
   if (render != null) {
-    return render({ ref, dynamicRef });
+    if (isInteractive) {
+      return render({ ref, dynamicRef });
+    }
+    return render({ ref });
+  }
+  if (isInteractive) {
+    return cloneElement(children, {
+      ref,
+      dynamicRef
+    });
   }
   return cloneElement(children, {
-    ref,
-    dynamicRef
+    ref
   });
 };

--- a/packages/demonstrators/social/flow/src/components/flow/DockItem.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/DockItem.tsx
@@ -89,6 +89,7 @@ export const DockItem: FC<DockItemPropsRoot> = ({
         key={`dock-item-${timelineId}-${postId}-${sliceId}`}
         id={nodeId}
         relations={relations}
+        isInteractive
       />
     ) : null;
   });

--- a/packages/demonstrators/social/flow/src/components/flow/FlowBody.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/FlowBody.tsx
@@ -70,7 +70,12 @@ export const FlowBody: FC = () => {
                 relations
               } = value;
               return (
-                <ArcherElement id={id} key={id} relations={relations}>
+                <ArcherElement
+                  id={id}
+                  key={id}
+                  relations={relations}
+                  isInteractive
+                >
                   <CustomBox>
                     <Typography variant='subtitle1'>{label}</Typography>
                   </CustomBox>

--- a/packages/demonstrators/social/flow/src/hocs/with-archer.tsx
+++ b/packages/demonstrators/social/flow/src/hocs/with-archer.tsx
@@ -5,11 +5,12 @@ import { DockItemArcherProps, DockItemProps, DockSliceArcherProps } from '../typ
 
 export const withArcher = (Comp: ComponentType<DockItemProps>) => {
   return (props: DockItemArcherProps | DockSliceArcherProps) => {
-    const { id, relations, ...rest } = props;
+    const { id, relations, isInteractive, ...rest } = props;
     return (
       <Archer.ArcherElement
         id={id}
         relations={relations}
+        isInteractive={isInteractive}
         render={renderProps => {
           return <Comp {...renderProps} {...rest} />;
         }}

--- a/packages/demonstrators/social/flow/src/types.tsx
+++ b/packages/demonstrators/social/flow/src/types.tsx
@@ -21,6 +21,7 @@ export interface DockItemProps {
     | Array<ScrollTypes.Timeline.NodeWithRelations>;
   otherTimelineId?: string;
   render?: ArcherTypes.RenderFn;
+  isInteractive?: boolean;
 }
 
 export type DockItemArcherProps = DockItemProps &
@@ -36,6 +37,7 @@ export interface DockSliceProps {
   id?: string;
   relations?: Array<ArcherTypes.Relation>;
   dynamicRef?: any;
+  isInteractive?: boolean;
 }
 
 export type DockSliceArcherProps = DockSliceProps &


### PR DESCRIPTION
The property gets used to either pass or copies the property "dynamicRef" to its children during the render props, respectively, the render method's clone logic. The property "isInteractive" gets disabled by default. A required use case where this property is relevant is the component flow body. A stepper component activates archer elements, respectively, its children one at a time to illustrate progress.