### PR TITLE
Include locale in decision when to route to base

### DIFF
--- a/build/webpack-build/package.json
+++ b/build/webpack-build/package.json
@@ -11,10 +11,10 @@
     "escalade": "^3.1.1"
   },
   "devDependencies": {
-    "enhanced-resolve": "^5.4.1",
+    "enhanced-resolve": "^5.6.0",
     "rimraf": "^3.0.2",
     "ts-loader": "^8.0.14",
     "typescript": "^4.1.3",
-    "webpack": "^5.12.3"
+    "webpack": "^5.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@rest-hooks/normalizr": "^5.0.6",
     "@types/resize-observer-browser": "^0.1.5",
     "@vangware/window-open-promise": "^4.0.10",
-    "ahooks": "^2.9.3",
+    "ahooks": "^2.9.4",
     "clsx": "^1.1.1",
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.16.1",
@@ -78,7 +78,7 @@
     "element-resize-detector": "^1.2.1",
     "factory.ts": "^0.5.1",
     "fast-glob": "^3.2.4",
-    "framer-motion": "^3.2.0",
+    "framer-motion": "^3.2.1",
     "gray-matter": "^4.0.2",
     "group-array": "^1.0.0",
     "immer": "^8.0.0",
@@ -112,7 +112,7 @@
     "uuid": "^8.3.2",
     "vfile": "^4.2.1",
     "victory": "^35.4.6",
-    "windups": "^1.1.2"
+    "windups": "^1.1.4"
   },
   "devDependencies": {
     "@types/draft-js": "^0.10.44",
@@ -126,8 +126,8 @@
     "@types/styled-components": "^5.1.7",
     "@types/unist": "^2.0.3",
     "@types/webpack-merge": "^4.1.5",
-    "@typescript-eslint/eslint-plugin": "^4.12.0",
-    "@typescript-eslint/parser": "^4.12.0",
+    "@typescript-eslint/eslint-plugin": "^4.13.0",
+    "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-import": "^2.22.1",
@@ -144,7 +144,7 @@
     "webpack-merge": "5.7.3"
   },
   "resolutions": {
-    "webpack": "5.12.3",
+    "webpack": "5.13.0",
     "styled-components": "^5.2.1",
     "next-translate": "1.0.1",
     "next": "10.0.5",

--- a/packages/app/layout/src/components/AppWrapper.tsx
+++ b/packages/app/layout/src/components/AppWrapper.tsx
@@ -19,7 +19,7 @@ export const jss = create({
 export const AppWrapper: FC = ({ children }) => {
   const { page } = useAnalytics();
 
-  const { asPath } = useRouter();
+  const { asPath, locale } = useRouter();
 
   const [navigation, setNavigation] = useRecoilState(navigationState);
 
@@ -30,7 +30,8 @@ export const AppWrapper: FC = ({ children }) => {
     const flattenedPages = RouterUtils.flattenPages(pages, 'children');
     const activePage = RouterUtils.findSelectedPageAsObject(
       flattenedPages,
-      asPath
+      asPath,
+      locale
     );
     setNavigation(state => {
       return {
@@ -47,7 +48,8 @@ export const AppWrapper: FC = ({ children }) => {
     if (asPath != null && flattenedPages != null && flattenedPages.length > 0) {
       const activePage = RouterUtils.findSelectedPageAsObject(
         flattenedPages,
-        asPath
+        asPath,
+        locale
       );
       setNavigation(state => {
         return {

--- a/packages/app/layout/src/components/LanguageMenu.tsx
+++ b/packages/app/layout/src/components/LanguageMenu.tsx
@@ -12,7 +12,7 @@ export const LanguageMenu: FC = () => {
 
   const { t } = useTranslation();
 
-  const { push, pathname, asPath, locale, query } = useRouter();
+  const { push, pathname, locale, query } = useRouter();
 
   const handleSelect = (languageCode: string) => {
     push(
@@ -20,7 +20,7 @@ export const LanguageMenu: FC = () => {
         pathname,
         query
       },
-      asPath,
+      null,
       { locale: languageCode }
     );
     setLanguageMenu(null);

--- a/packages/page/landing/src/components/TopicsViewDesktop.tsx
+++ b/packages/page/landing/src/components/TopicsViewDesktop.tsx
@@ -1,5 +1,6 @@
 import { CustomIcon } from '@app/components';
 import { ContentTypes } from '@app/types';
+import { StringUtil } from '@app/utils';
 import { createStyles, Grid, IconButton, makeStyles, Theme } from '@material-ui/core';
 import { useRouter } from 'next/router';
 import React, { FC, useEffect } from 'react';
@@ -47,14 +48,19 @@ export const TopicsViewDesktop: FC<TopicsViewDesktopProps> = ({ topics }) => {
   });
 
   useEffect(() => {
-    push(
-      {
-        pathname,
-        query
-      },
-      asPath,
-      { locale }
-    );
+    if (
+      !StringUtil.isEmptyString(query.aspect) &&
+      !StringUtil.isEmptyString(query.feature)
+    ) {
+      push(
+        {
+          pathname,
+          query
+        },
+        asPath,
+        { locale }
+      );
+    }
   }, []);
 
   return (

--- a/packages/utils/src/router/index.ts
+++ b/packages/utils/src/router/index.ts
@@ -51,7 +51,8 @@ const findSelectedPage = (
 
 const findSelectedPageAsObject = (
   flattenedPages: Array<PageTypes.FlattenedPage>,
-  pathname: string
+  pathname: string,
+  locale: string
 ) => {
   if (pathname.indexOf('?') > 0) {
     pathname = pathname.substring(0, pathname.indexOf('?'));
@@ -61,7 +62,7 @@ const findSelectedPageAsObject = (
     pathname = pathname.substring(0, pathname.indexOf('#'));
   }
 
-  if (pathname === '/') {
+  if (pathname === '/' || pathname === `/${locale}`) {
     return {
       pathname: '/'
     };

--- a/packages/utils/src/string/index.ts
+++ b/packages/utils/src/string/index.ts
@@ -1,3 +1,1 @@
-import { stringToArray } from './string';
-
-export { stringToArray };
+export { isEmptyString, stringToArray } from './string';

--- a/packages/utils/src/string/string.ts
+++ b/packages/utils/src/string/string.ts
@@ -1,5 +1,12 @@
 import isArray from 'lodash/isArray';
 
+export const isEmptyString = (value: string) => {
+  if (typeof value === 'string' && value.length === 0) {
+    return true;
+  }
+  return false;
+};
+
 export const stringToArray = (text: Array<string> | string) => {
   if (isArray(text)) {
     return [...text];

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,12 +307,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@app/webpack-build@workspace:build/webpack-build"
   dependencies:
-    enhanced-resolve: ^5.4.1
+    enhanced-resolve: ^5.6.0
     escalade: ^3.1.1
     rimraf: ^3.0.2
     ts-loader: ^8.0.14
     typescript: ^4.1.3
-    webpack: ^5.12.3
+    webpack: ^5.13.0
   languageName: unknown
   linkType: soft
 
@@ -3318,14 +3318,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.12.0"
+"@typescript-eslint/eslint-plugin@npm:^4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.13.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.12.0
-    "@typescript-eslint/scope-manager": 4.12.0
+    "@typescript-eslint/experimental-utils": 4.13.0
+    "@typescript-eslint/scope-manager": 4.13.0
     debug: ^4.1.1
     functional-red-black-tree: ^1.0.1
+    lodash: ^4.17.15
     regexpp: ^3.0.0
     semver: ^7.3.2
     tsutils: ^3.17.1
@@ -3335,66 +3336,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3817b2854d4f206d59a8231ba364d13cbba8cc24b17cb214c5460b65760da2e2f2636939be61093663ce180d82851a82024cf78feefec3c38ad229f11076bdac
+  checksum: 98f6ab92683965a75dfc966c3aa68d8b620b6fa5ff43048b7e249848c09c2a8bf7aaf7c4fa32b8c1203d8bc083279269ca291b12b5775d444806f9e22a4f21a1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/experimental-utils@npm:4.12.0"
+"@typescript-eslint/experimental-utils@npm:4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/experimental-utils@npm:4.13.0"
   dependencies:
     "@types/json-schema": ^7.0.3
-    "@typescript-eslint/scope-manager": 4.12.0
-    "@typescript-eslint/types": 4.12.0
-    "@typescript-eslint/typescript-estree": 4.12.0
+    "@typescript-eslint/scope-manager": 4.13.0
+    "@typescript-eslint/types": 4.13.0
+    "@typescript-eslint/typescript-estree": 4.13.0
     eslint-scope: ^5.0.0
     eslint-utils: ^2.0.0
   peerDependencies:
     eslint: "*"
-  checksum: f6557c42025597b6d88d11cefcb06769c496c7e56a78c9e45cd69dd8031ba4fe8dead8ff31c7ac3b871122518ee3370463aa7420efa033198db8e5de2087397a
+  checksum: 63eee348ddc77bca7547be8a3b8759e4bcff30cf8a04e27a224bf8221d68ad8e4e1634fdd0aebdff7dc29d32a82dfa6ee70ec03d7d69d3c7128ae221f2711d1a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/parser@npm:4.12.0"
+"@typescript-eslint/parser@npm:^4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/parser@npm:4.13.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.12.0
-    "@typescript-eslint/types": 4.12.0
-    "@typescript-eslint/typescript-estree": 4.12.0
+    "@typescript-eslint/scope-manager": 4.13.0
+    "@typescript-eslint/types": 4.13.0
+    "@typescript-eslint/typescript-estree": 4.13.0
     debug: ^4.1.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 4aebb32fdc2de8fcd659b06a3e3fdb74f56edc229962ce1ebdcacffee94bbd9222bceae7372e594e27d5302ed6c49a08378e4f892b4022e9939ae8df5478f7a0
+  checksum: 7eec410392d618eddfa421fd6d1449bba1312abc90bd81dcbea33d3083788616c50e97e98ac11fbce1600f827fc7d04e50296f56366fcdd37a54b08558812319
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.12.0"
+"@typescript-eslint/scope-manager@npm:4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/scope-manager@npm:4.13.0"
   dependencies:
-    "@typescript-eslint/types": 4.12.0
-    "@typescript-eslint/visitor-keys": 4.12.0
-  checksum: 9b88f650ca684b60d4a5633e7c142dbb7b309a27632f54717bc215a90b218ef0524cf37c8436f024b1998b7547a29e25e7eafc44fefd28cc10f8c06db0fb0eb4
+    "@typescript-eslint/types": 4.13.0
+    "@typescript-eslint/visitor-keys": 4.13.0
+  checksum: 878302870ee46f5b311bcee7984514eb4f81caea618010983abd75f5395faf9b6ca2c76f82d43b221946672494fac593c697b5b8644d7a3ae70fc03b9c166d12
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/types@npm:4.12.0"
-  checksum: e7748085a6b3ee13e1cd05a1ef14310f5cf32bdf3969231226ad2ca7d47a4fb3995c952394fe76d8c8437a4a8d166e37189bbeb49b5603cbd9daa61c60936b3b
+"@typescript-eslint/types@npm:4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/types@npm:4.13.0"
+  checksum: ed2e27ad1f7d0db28d13d3a5fe900b7638981689fea1b5556de4fcd87729f73cfe2e3792005cf4e05ba4c405f2abe9bc55c076354d4ac3f9576ded65c1b4ddf5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.12.0"
+"@typescript-eslint/typescript-estree@npm:4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/typescript-estree@npm:4.13.0"
   dependencies:
-    "@typescript-eslint/types": 4.12.0
-    "@typescript-eslint/visitor-keys": 4.12.0
+    "@typescript-eslint/types": 4.13.0
+    "@typescript-eslint/visitor-keys": 4.13.0
     debug: ^4.1.1
     globby: ^11.0.1
     is-glob: ^4.0.1
@@ -3404,17 +3405,17 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: beb93c795dc43d022093cef85554abecce192c3b27fc9435bcdc8f0f3fb5901d0dc6c3866686fe6c12d7b492d0dfd51b456ac052c6e2aa14c3b6f610c014bf88
+  checksum: 8b7485f192f247d659779f1bc95d927612e53b23801981acc462c2fd76219a61ac1094348bf7ac46034b58c1751793053128d11264268e378241eb6e686f5e8e
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.12.0":
-  version: 4.12.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.12.0"
+"@typescript-eslint/visitor-keys@npm:4.13.0":
+  version: 4.13.0
+  resolution: "@typescript-eslint/visitor-keys@npm:4.13.0"
   dependencies:
-    "@typescript-eslint/types": 4.12.0
+    "@typescript-eslint/types": 4.13.0
     eslint-visitor-keys: ^2.0.0
-  checksum: 8825210cd8a729415fed4244406ca5ba9d02fa81719572f955d98cd08e378923fe553d9f71e4557f3ba14b191aba98e5d6207cc002a17d04078d9ca0d6c46855
+  checksum: 35f20062885da380ef9d6e07f058ea9629a36b3d264dcf7e776e81da7c8f544373a287d6f49c88fd4fc546bb4afea27efdcd4e5be972c4202746b46cf1682a2d
   languageName: node
   linkType: hard
 
@@ -3702,9 +3703,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ahooks@npm:^2.9.3":
-  version: 2.9.3
-  resolution: "ahooks@npm:2.9.3"
+"ahooks@npm:^2.9.4":
+  version: 2.9.4
+  resolution: "ahooks@npm:2.9.4"
   dependencies:
     "@ahooksjs/use-request": ^2.8.1
     "@types/js-cookie": ^2.2.6
@@ -3718,7 +3719,7 @@ __metadata:
     screenfull: ^5.0.0
   peerDependencies:
     react: ^16.8.6
-  checksum: 1fc12951f137930ac54b95511624b60641cacf5a95cae8c9b2583f40e871a4d1db0df20dc7143d0e758cf45ae21975ff3a727664754a000671d8041ce5e3e44b
+  checksum: a55a40421262d6a7992a8496629e39aa018df84fe684244f54f379dd2cc076286f5e363b6157902f610ac604a44f07508ec56d85952753ecf9cbd47c36f46a7a
   languageName: node
   linkType: hard
 
@@ -6021,13 +6022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.3.1, enhanced-resolve@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "enhanced-resolve@npm:5.4.1"
+"enhanced-resolve@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "enhanced-resolve@npm:5.6.0"
   dependencies:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
-  checksum: 2bc3f7b56f6e278577dd6a8b48a42befd9e8fb844a9113153713ef79e345d0747d39b6f052c3bed81ce25b1989cddf87293941490487585def2836b2f6356fa1
+  checksum: c43bc831c7b8173b948148ede388501174474dcf8cc7c1888b7d13e58bf59aab52f5976625ec016ca821f6ff4ba140e57f0a4416e48a8347b46271b077d9f178
   languageName: node
   linkType: hard
 
@@ -6934,9 +6935,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "framer-motion@npm:3.2.0"
+"framer-motion@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "framer-motion@npm:3.2.1"
   dependencies:
     "@emotion/is-prop-valid": ^0.8.2
     framesync: ^5.0.0
@@ -6950,7 +6951,7 @@ __metadata:
   dependenciesMeta:
     "@emotion/is-prop-valid":
       optional: true
-  checksum: 25bbc12d28f9229f1b1270e21d40ede60ebd5d18db4a49fbf84464920702a412e559fb413e415ab38ed25380d2cdf4c9308d0a6cd511e7ab768ed57d948606a5
+  checksum: 6a21a6502edc589938fda78238144648d3ae9197d2fc8455f7ed825c85cbe85f641ef1cf5e2371dadb3017331c1abef8737c81587cb055f01b2f99b71025c98b
   languageName: node
   linkType: hard
 
@@ -9506,10 +9507,10 @@ fsevents@~2.1.2:
     "@types/styled-components": ^5.1.7
     "@types/unist": ^2.0.3
     "@types/webpack-merge": ^4.1.5
-    "@typescript-eslint/eslint-plugin": ^4.12.0
-    "@typescript-eslint/parser": ^4.12.0
+    "@typescript-eslint/eslint-plugin": ^4.13.0
+    "@typescript-eslint/parser": ^4.13.0
     "@vangware/window-open-promise": ^4.0.10
-    ahooks: ^2.9.3
+    ahooks: ^2.9.4
     clsx: ^1.1.1
     copy-to-clipboard: ^3.3.1
     date-fns: ^2.16.1
@@ -9523,7 +9524,7 @@ fsevents@~2.1.2:
     eslint-plugin-react-hooks: ^4.2.0
     factory.ts: ^0.5.1
     fast-glob: ^3.2.4
-    framer-motion: ^3.2.0
+    framer-motion: ^3.2.1
     gray-matter: ^4.0.2
     group-array: ^1.0.0
     immer: ^8.0.0
@@ -9565,7 +9566,7 @@ fsevents@~2.1.2:
     vfile: ^4.2.1
     victory: ^35.4.6
     webpack-merge: 5.7.3
-    windups: ^1.1.2
+    windups: ^1.1.4
   languageName: unknown
   linkType: soft
 
@@ -14202,9 +14203,9 @@ typescript@^4.1.3:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.12.3":
-  version: 5.12.3
-  resolution: "webpack@npm:5.12.3"
+"webpack@npm:5.13.0":
+  version: 5.13.0
+  resolution: "webpack@npm:5.13.0"
   dependencies:
     "@types/eslint-scope": ^3.7.0
     "@types/estree": ^0.0.45
@@ -14214,7 +14215,7 @@ typescript@^4.1.3:
     acorn: ^8.0.4
     browserslist: ^4.14.5
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.3.1
+    enhanced-resolve: ^5.6.0
     eslint-scope: ^5.1.1
     events: ^3.2.0
     glob-to-regexp: ^0.4.1
@@ -14234,7 +14235,7 @@ typescript@^4.1.3:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 13cf14fc114b1c984a7ad3f6f8db79d3980f4e366c174a57a7d2d497b09d26df5061e91e54465b55df2819340b1ec8a83e648d1016c52880e02d8a468de8875a
+  checksum: 2967f16f9444389139a2d48b9607f1fc651634ffc7934aaaa94228e44f4a0d4fe3dcb88478d7f8399005ee9c3af674366b40f05bf7b7d9e077fa27c90072e30d
   languageName: node
   linkType: hard
 
@@ -14328,14 +14329,14 @@ typescript@^4.1.3:
   languageName: node
   linkType: hard
 
-"windups@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "windups@npm:1.1.2"
+"windups@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "windups@npm:1.1.4"
   dependencies:
     break-styled-lines: ^1.2.1
   peerDependencies:
     react: ^16.8.0
-  checksum: 0af478a675548e6dbdb4603ad9491cc359ff6b6e7347d6185eb2122ba9082a312831fe92f251e30183e4ee069b84b29973046fbdb9605bcb60ed7a6160b2ba1c
+  checksum: 12181feef4437e09165112213e601cc1c64247a6a22579001796610cf79878992f6130c4c079c22dc2fa2020ded14450123510c0664df03515e83b652d47c9a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix changing locale with queries

Due to a change in route handling, the parameter "asPath" of a router push needs to be null to trigger a route change.

The occurs only when the existing path includes one or more query parameters. Changing the route from a default locale to a secondary locale was possible, but not the outer way around.

We have to monitor the situation in upcoming releases of NextJs; maybe a bug was introduced in the following commit, which deals with basePath with a query and evaluating the function parameters.

https://github.com/vercel/next.js/commit/47b7660aec950d2985f1d137d574fb84b935d555

It worked like a charm in 10.0.5-canary.9 but stopped working in 10.0.5-canary.10. From version 10.0.5-canary.10 the changes in this commit are necessary.

Only push on mount when query values are not empty

Update dependencies