### PR TITLE
Improve toc styles

### DIFF
--- a/packages/page/layout/src/components/AppTableOfContents.tsx
+++ b/packages/page/layout/src/components/AppTableOfContents.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme: Theme) =>
       flexShrink: 0,
       position: 'sticky',
       height: 'calc(100% - 96px)',
+      margin: theme.spacing(1),
       overflowY: 'auto',
       display: 'none',
       [theme.breakpoints.up('sm')]: {
@@ -22,18 +23,14 @@ const useStyles = makeStyles((theme: Theme) =>
       },
       '& ul': {
         paddingLeft: 0,
-        listStyle: 'none',
-        '& li': {
-          // paddingLeft: theme.spacing(2),
-          color: theme.palette.text.primary
-        }
-      },
-      margin: theme.spacing(3)
+        listStyle: 'none'
+      }
     },
     tocHeader: {
       height: 56,
       padding: theme.spacing(1),
-      fontSize: '1rem'
+      fontSize: 16,
+      fontWeight: 'bold'
     }
   })
 );

--- a/packages/page/layout/src/components/toc/TocLink.tsx
+++ b/packages/page/layout/src/components/toc/TocLink.tsx
@@ -12,11 +12,15 @@ export const useStyles = makeStyles((theme: Theme) =>
     item: {
       display: 'block',
       padding: theme.spacing(1),
-      color: theme.palette.text.secondary,
-      textDecoration: 'none'
+      textDecoration: 'none',
+      borderLeft: `2px solid transparent`,
+      '&:hover': {
+        borderLeftColor: theme.palette.grey[200],
+        cursor: 'pointer'
+      }
     },
     active: {
-      borderLeft: `2px solid ${theme.palette.primary.main}`,
+      borderLeft: `2px solid ${theme.palette.grey[300]}`,
       color: theme.palette.text.primary
     }
   })
@@ -42,6 +46,8 @@ export const TocLink: FC<TocLinkProps> = ({ href, children }) => {
 
   const { scrollItems } = useRecoilValue(scrollItemsState);
   const isActive = processLink(scrollItems, href);
+
+  // const { query } = useRouter();
 
   // Use - when NextJs resolves a bug with dynamic pages and hash
   // return (


### PR DESCRIPTION
Add consistent border-left style. In default, hover, and active state, left = 2px. Before, no border-left got defined for default and hover state; it resulted in a position shift when the user navigates the component table of contents.