### PR TITLE
Onboard bottom sheet feature

### DIFF
--- a/packages/demonstrator/components/src/index.ts
+++ b/packages/demonstrator/components/src/index.ts
@@ -1,3 +1,4 @@
 export { Player, PlayerTypes, PlayerUtils, PlayerHooks } from './player';
 export { StepProvider, useStepState, useStepDispatch } from './player/context';
 export { Cursor } from './cursor';
+export * as Sheet from './sheet';

--- a/packages/demonstrator/components/src/sheet/components/Sheet.tsx
+++ b/packages/demonstrator/components/src/sheet/components/Sheet.tsx
@@ -1,0 +1,107 @@
+import { AnimatePresence, useSpring } from 'framer-motion';
+import React, { forwardRef, ForwardRefRenderFunction, ReactNode, useImperativeHandle, useRef } from 'react';
+import styled from 'styled-components';
+
+import { SheetContext } from '../context/SheetContext';
+import { SheetHandleProps } from '../types';
+
+interface SheetWrapperProps {
+  bottom: number;
+  width: number;
+}
+
+const SheetWrapper = styled.div<SheetWrapperProps>`
+  position: absolute;
+  top: 0;
+  bottom: ${({ bottom }) => `${bottom}px`};
+  width: ${({ width }) => `${width}px`};
+  overflow: hidden;
+  z-index: 4;
+`;
+
+type SheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  snapPoints: Array<number>;
+  initialSnapPointIndex: number;
+  size: Partial<DOMRect>;
+  bottomSize: Partial<DOMRect>;
+  children: ReactNode;
+};
+
+const Sheet: ForwardRefRenderFunction<SheetHandleProps, SheetProps> = (
+  {
+    children,
+    isOpen,
+    onClose,
+    snapPoints,
+    initialSnapPointIndex,
+    size,
+    bottomSize
+  },
+  forwardedRef
+) => {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  const sheetSpringY = useSpring(size.height, {
+    stiffness: 100,
+    damping: 10,
+    mass: 0.01
+  });
+
+  useImperativeHandle(forwardedRef, () => ({
+    snapTo: (snapIndex: number) => {
+      if (snapPoints && snapPoints[snapIndex] !== undefined) {
+        const sheetEl = sheetRef.current;
+        // const sheetElHeight = sheetEl.getBoundingClientRect().height;
+        const sheetElHeight = sheetEl.parentElement.getBoundingClientRect()
+          .height;
+        const snapTo = sheetElHeight - snapPoints[snapIndex];
+        if (snapTo < 0) {
+          sheetSpringY.set(0);
+        } else {
+          sheetSpringY.set(snapTo);
+        }
+      }
+    },
+    snapToPx: (height: number, offsetTop: number) => {
+      const sheetEl = sheetRef.current;
+      // const sheetElHeight = sheetEl.getBoundingClientRect().height;
+      const sheetElHeight = sheetEl.parentElement.getBoundingClientRect()
+        .height;
+
+      const snapTo = size.height - (bottomSize.height + height + offsetTop);
+
+      sheetSpringY.set(snapTo);
+
+      if (snapTo >= sheetElHeight || snapTo < 0) {
+        onClose();
+      }
+    }
+  }));
+
+  const context = {
+    sheetRef,
+    isOpen,
+    snapPoints,
+    initialSnapPointIndex,
+    y: sheetSpringY
+  };
+
+  return (
+    <SheetContext.Provider value={context}>
+      <SheetWrapper width={size.width} bottom={bottomSize.height}>
+        {/* <AnimatePresence>
+          {isOpen && RenderUtils.hasChildren(children)
+            ? Children.map(children, (child, index) => {
+                cloneElement(child, { key: `sheet-child-${index}` });
+              })
+            : null}
+        </AnimatePresence> */}
+        <AnimatePresence>{isOpen ? children : null}</AnimatePresence>
+      </SheetWrapper>
+    </SheetContext.Provider>
+  );
+};
+
+export default forwardRef(Sheet);

--- a/packages/demonstrator/components/src/sheet/components/SheetContainer.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetContainer.tsx
@@ -1,0 +1,56 @@
+import { motion } from 'framer-motion';
+import React, { FC } from 'react';
+
+import { useSheetContext } from '../context/SheetContext';
+
+type SheetContainerProps = {
+  size: Partial<DOMRect>;
+  bottomSize: Partial<DOMRect>;
+};
+
+const SheetContainer: FC<SheetContainerProps> = ({
+  children,
+  size,
+  bottomSize
+}) => {
+  const {
+    snapPoints,
+    initialSnapPointIndex = 0,
+    sheetRef,
+    y
+  } = useSheetContext();
+
+  const [maxSnapPoint] = snapPoints && snapPoints.length > 0 ? snapPoints : [0];
+
+  const initialSnapPoint =
+    snapPoints && snapPoints.length >= initialSnapPointIndex
+      ? snapPoints[initialSnapPointIndex]
+      : 0;
+
+  const sheetHeight = maxSnapPoint
+    ? Math.min(maxSnapPoint, size.height)
+    : size.height;
+
+  const initialY = size.height - (bottomSize.height + initialSnapPoint);
+
+  return (
+    <motion.div
+      ref={sheetRef}
+      style={{
+        height: sheetHeight,
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#fff',
+        zIndex: 2,
+        y
+      }}
+      initial={{ y: size.height }}
+      animate={{ y: initialY }}
+      exit={{ y: size.height }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default SheetContainer;

--- a/packages/demonstrator/components/src/sheet/components/SheetContent.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetContent.tsx
@@ -1,0 +1,18 @@
+import { createStyles, makeStyles } from '@material-ui/core';
+import React, { FC } from 'react';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    content: {
+      display: 'flex',
+      flexDirection: 'column',
+      margin: '24px'
+    }
+  })
+);
+
+export const SheetContent: FC = ({ children }) => {
+  const classes = useStyles();
+
+  return <div className={classes.content}>{children}</div>;
+};

--- a/packages/demonstrator/components/src/sheet/components/SheetHeader.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetHeader.tsx
@@ -1,0 +1,37 @@
+import { createStyles, makeStyles } from '@material-ui/core';
+import React, { FC } from 'react';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    headerWrapper: {
+      width: '100%'
+    },
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '100%',
+      height: '40px',
+      position: 'relative'
+    },
+    indicator: {
+      width: '18px',
+      height: '4px',
+      backgroundColor: '#ddd'
+    }
+  })
+);
+
+export const SheetHeader: FC = ({ children }) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.headerWrapper}>
+      {children || (
+        <div className={classes.header}>
+          <span className={classes.indicator} />
+          <span className={classes.indicator} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/demonstrator/components/src/sheet/components/index.ts
+++ b/packages/demonstrator/components/src/sheet/components/index.ts
@@ -1,0 +1,4 @@
+export { default as Sheet } from './Sheet';
+export { default as SheetContainer } from './SheetContainer';
+export { SheetContent } from './SheetContent';
+export { SheetHeader } from './SheetHeader';

--- a/packages/demonstrator/components/src/sheet/context/SheetContext.tsx
+++ b/packages/demonstrator/components/src/sheet/context/SheetContext.tsx
@@ -1,0 +1,18 @@
+import { MotionValue } from 'framer-motion';
+import { createContext, useContext, MutableRefObject } from 'react';
+
+export type SheetContextProps = {
+  sheetRef: MutableRefObject<HTMLDivElement>;
+  isOpen: boolean;
+  snapPoints: Array<number>;
+  initialSnapPointIndex: number;
+  y: MotionValue<number>;
+};
+
+export const SheetContext = createContext<SheetContextProps>(null);
+
+export const useSheetContext = () => {
+  const context = useContext(SheetContext);
+  if (!context) throw Error('Sheet context error');
+  return context;
+};

--- a/packages/demonstrator/components/src/sheet/hooks/index.ts
+++ b/packages/demonstrator/components/src/sheet/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useBottomSheetActions } from './useBottomSheetActions';

--- a/packages/demonstrator/components/src/sheet/hooks/useBottomSheetActions.tsx
+++ b/packages/demonstrator/components/src/sheet/hooks/useBottomSheetActions.tsx
@@ -1,0 +1,42 @@
+import { MutableRefObject, useCallback } from 'react';
+
+import { SheetHandleProps } from '../types';
+
+export const useBottomSheetActions = (
+  sheetRef: MutableRefObject<SheetHandleProps>
+) => {
+  const snapTo = useCallback(
+    (index: number) => {
+      try {
+        sheetRef.current?.snapTo(index);
+      } catch (e) {
+        if (e instanceof TypeError) {
+          // If the bottomsheet isn't visible this may throw an error
+          // ignore
+          return;
+        }
+        throw e;
+      }
+    },
+    [sheetRef]
+  );
+  const snapToPx = useCallback(
+    (height: number, offsetTop: number) => {
+      try {
+        sheetRef.current?.snapToPx(height, offsetTop);
+      } catch (e) {
+        if (e instanceof TypeError) {
+          // If the bottomsheet isn't visible this may throw an error
+          // ignore
+          return;
+        }
+        throw e;
+      }
+    },
+    [sheetRef]
+  );
+  return {
+    snapTo,
+    snapToPx
+  };
+};

--- a/packages/demonstrator/components/src/sheet/index.ts
+++ b/packages/demonstrator/components/src/sheet/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * as Hooks from './hooks';
+export * as Types from './types';

--- a/packages/demonstrator/components/src/sheet/types/index.ts
+++ b/packages/demonstrator/components/src/sheet/types/index.ts
@@ -1,0 +1,4 @@
+export type SheetHandleProps = {
+  snapTo: (snapIndex: number) => void;
+  snapToPx: (height: number, offsetTop: number) => void;
+};


### PR DESCRIPTION
The idea behind the bottom sheet feature is to save space by hiding significant parts of the player component such as playlist, text replay, and others behind an expandable alike visual element.