### PR TITLE
Change composition of timeline alike components

### DIFF
--- a/packages/demonstrators/social/layout/src/components/comment/CommentEditor.tsx
+++ b/packages/demonstrators/social/layout/src/components/comment/CommentEditor.tsx
@@ -1,6 +1,7 @@
 import { RenderUtils } from '@app/render-utils';
 import { useEffectRef } from '@huse/effect-ref';
 import { Button, createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
+import SendIcon from '@material-ui/icons/Send';
 import { useWindupString } from '@project-millipede/windups';
 import { ContentState, Editor, EditorState } from 'draft-js';
 import elementResizeDetectorMaker from 'element-resize-detector';
@@ -60,8 +61,6 @@ export const CommentEditor: FC<CommentEditorProps> = ({
     }`
   );
   const contentEmpty = t('pages/pidp/use-case/recognition/index:content_empty');
-
-  // const contentInput = t('pages/pidp/use-case/recognition/index:content_input');
 
   const [commentState, setCommentState] = useState(() =>
     EditorState.createEmpty()
@@ -137,14 +136,27 @@ export const CommentEditor: FC<CommentEditorProps> = ({
           {contentEmpty}
         </Typography>
       )}
-      <Button
-        variant='text'
-        color='primary'
-        onClick={handlePostComment}
-        id={`timeline-${timelineId}-content-post`}
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
       >
-        {postButtonTitle}
-      </Button>
+        <Button
+          id={`timeline-${timelineId}-content-post`}
+          variant='text'
+          color='primary'
+          startIcon={<SendIcon />}
+          onClick={handlePostComment}
+          style={{
+            textTransform: 'none'
+          }}
+        >
+          {postButtonTitle}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/demonstrators/social/layout/src/components/post/Post.tsx
+++ b/packages/demonstrators/social/layout/src/components/post/Post.tsx
@@ -6,17 +6,9 @@ import {
   scrollStates,
   ScrollTypes,
   selectors,
-  TimelineActions
+  TimelineActions,
 } from '@demonstrators-social/shared';
-import {
-  Button,
-  ButtonGroup,
-  Card,
-  CardActions,
-  createStyles,
-  ListItem,
-  makeStyles
-} from '@material-ui/core';
+import { Button, ButtonGroup, Card, createStyles, ListItem, makeStyles } from '@material-ui/core';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
@@ -25,22 +17,11 @@ import { enGB } from 'date-fns/locale';
 import lodashGet from 'lodash/get';
 import useTranslation from 'next-translate/useTranslation';
 import React, { Dispatch, FC, useMemo, useState } from 'react';
-import {
-  selectorFamily,
-  SerializableParam,
-  useRecoilValue,
-  useSetRecoilState
-} from 'recoil';
+import { selectorFamily, SerializableParam, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { CommentEditor } from '../comment/CommentEditor';
 import { Comments } from '../comment/Comments';
-import {
-  getContent,
-  getHeader,
-  getMedia,
-  getObserverComp,
-  getRef
-} from './Post.Render.svc';
+import { getContent, getHeader, getMedia, getObserverComp, getRef } from './Post.Render.svc';
 import { handleCreateComment, handleDeletePost } from './Post.svc';
 
 const { selectPostById, selectTimelineOwner } = selectors.timeline;
@@ -159,29 +140,31 @@ export const Post: FC<PostProps> = ({
   const contentComp = getObserverComp(getRefForId('content'))(getContent(text));
 
   const sentimentComp = getObserverComp(getRefForId('sentiment'))(
-    <CardActions disableSpacing>
-      <ButtonGroup variant='text' color='primary' style={{ margin: 'auto' }}>
-        <Button variant='text' color='primary' startIcon={<ThumbUpIcon />}>
-          {t('pages/pidp/use-case/recognition/index:like')}
-        </Button>
-        <Button
-          variant='text'
-          color='primary'
-          startIcon={<ChatBubbleOutlineIcon />}
-          onClick={() => setDisplayEditor(true)}
-        >
-          {t('pages/pidp/use-case/recognition/index:comment')}
-        </Button>
-        <Button
-          variant='text'
-          color='primary'
-          startIcon={<DeleteOutlineIcon />}
-          onClick={() => handleDeletePost(timelineId, postId, dispatch)}
-        >
-          {t('pages/pidp/use-case/recognition/index:delete')}
-        </Button>
-      </ButtonGroup>
-    </CardActions>
+    <ButtonGroup variant='text' color='primary' size='large' fullWidth>
+      <Button
+        id={`timeline-${timelineId}-post-${postId}-comment-like`}
+        aria-label={t('pages/pidp/use-case/recognition/index:like')}
+        variant='text'
+        color='primary'
+        startIcon={<ThumbUpIcon />}
+      />
+      <Button
+        id={`timeline-${timelineId}-post-${postId}-comment-create`}
+        aria-label={t('pages/pidp/use-case/recognition/index:comment')}
+        variant='text'
+        color='primary'
+        startIcon={<ChatBubbleOutlineIcon />}
+        onClick={() => setDisplayEditor(true)}
+      />
+      <Button
+        id={`timeline-${timelineId}-post-${postId}-comment-delete`}
+        aria-label={t('pages/pidp/use-case/recognition/index:delete')}
+        variant='text'
+        color='primary'
+        startIcon={<DeleteOutlineIcon />}
+        onClick={() => handleDeletePost(timelineId, postId, dispatch)}
+      />
+    </ButtonGroup>
   );
 
   const commentComp = getObserverComp(getRefForId('comments'))(
@@ -239,6 +222,7 @@ export const Post: FC<PostProps> = ({
                 setDisplayEditor(false);
               });
             }}
+            timelineId={timelineId}
             isComment
           />
         ) : null}

--- a/packages/demonstrators/social/layout/src/components/timeline/Timeline.tsx
+++ b/packages/demonstrators/social/layout/src/components/timeline/Timeline.tsx
@@ -1,21 +1,9 @@
 import { useHoux } from '@app/houx';
 import { CollectionUtil } from '@app/utils';
-import {
-  RootState,
-  scrollStates,
-  ScrollTypes,
-  selectors,
-  TimelineActions
-} from '@demonstrators-social/shared';
+import { RootState, scrollStates, ScrollTypes, selectors, TimelineActions } from '@demonstrators-social/shared';
 import { useMergedRef } from '@huse/merged-ref';
-import {
-  Button,
-  ButtonGroup,
-  List,
-  makeStyles,
-  useTheme
-} from '@material-ui/core';
-import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
+import { Button, List, makeStyles, useTheme } from '@material-ui/core';
+import CreateIcon from '@material-ui/icons/Create';
 import get from 'lodash/get';
 import useTranslation from 'next-translate/useTranslation';
 import React, { Dispatch, FC, useEffect, useState } from 'react';
@@ -116,7 +104,11 @@ export const Timeline: FC<TimelineProps> = ({
 
       <div
         key={`timeline-${timelineId}`}
-        style={{ overflowY: 'auto', height: '65vh', marginTop: '8px' }}
+        style={{
+          overflowY: 'auto',
+          height: '65vh',
+          marginTop: '8px'
+        }}
       >
         {currentView === ScrollTypes.Timeline.VIEW.POSTS && displayEditor && (
           <CommentEditor
@@ -132,18 +124,26 @@ export const Timeline: FC<TimelineProps> = ({
         )}
 
         {currentView === ScrollTypes.Timeline.VIEW.POSTS && !displayEditor && (
-          <ButtonGroup variant='text' color='primary' style={{ width: '100%' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
+            }}
+          >
             <Button
               id={`timeline-${timelineId}-content-create`}
               variant='text'
               color='primary'
-              startIcon={<ChatBubbleOutlineIcon />}
+              startIcon={<CreateIcon />}
               onClick={() => setDisplayEditor(true)}
-              style={{ margin: 'auto' }}
+              style={{
+                textTransform: 'none'
+              }}
             >
               {t('pages/pidp/use-case/recognition/index:content_create')}
             </Button>
-          </ButtonGroup>
+          </div>
         )}
         <List
           key={`timeline-${timelineId}`}


### PR DESCRIPTION
Do not use a button-group when a single button gets used; instead, use a simple div to provide a layout. Remove card-actions as a wrapper of button-group. Show only icons, no labels in sentiment buttons.