### PR TITLE
Change loading  behaviour of pdf components

### DIFF
--- a/docs/src/lib/getComponents.tsx
+++ b/docs/src/lib/getComponents.tsx
@@ -8,9 +8,8 @@ const checkForComponentUse = (tagName: string, content: string) => {
 // Contains the list of components that can be embed in MDX files
 const components = {
   Tag: dynamic(() => import('@app/components').then(module => module.Tag)),
-  PDF: dynamic(
-    () => import('@app/components').then(module => module.Pdf.StepperContent),
-    { ssr: false }
+  PDF: dynamic(() =>
+    import('@app/components').then(module => module.Pdf.StepperContent)
   ),
   Demonstrator: dynamic(() =>
     import('@demonstrators-social/layout').then(module => module.Demonstrator)

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@project-millipede/windups": "^1.1.12",
     "@rest-hooks/normalizr": "^5.0.6",
     "@stefanprobst/next-svg": "^1.0.4",
+    "@types/pdfjs-dist": "^2.1.7",
     "@types/resize-observer-browser": "^0.1.5",
     "@vangware/window-open-promise": "^4.0.10",
     "ahooks": "^2.9.6",

--- a/packages/app/components/src/pdf/StepperContent.tsx
+++ b/packages/app/components/src/pdf/StepperContent.tsx
@@ -1,11 +1,26 @@
 import { Button, Grid } from '@material-ui/core';
+import dynamic from 'next/dynamic';
 import React, { FC, useState } from 'react';
-import { Document, Page, pdfjs } from 'react-pdf';
+import { DocumentProps, PageProps } from 'react-pdf';
 import { SizeMe } from 'react-sizeme';
 
 import { Stepper, TranslationProps } from '../stepper/Stepper';
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+const Document = dynamic<DocumentProps>(
+  () => import('react-pdf').then(module => module.Document),
+  { ssr: false }
+);
+
+const Page = dynamic<PageProps>(
+  () => import('react-pdf').then(module => module.Page),
+  {
+    ssr: false
+  }
+);
+
+import('react-pdf').then(({ pdfjs }) => {
+  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+});
 
 export type StepperContentWithTranslationProps = TranslationProps & {
   url: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pdfjs-dist@npm:*":
+"@types/pdfjs-dist@npm:*, @types/pdfjs-dist@npm:^2.1.7":
   version: 2.1.7
   resolution: "@types/pdfjs-dist@npm:2.1.7"
   checksum: ea39ddd1d03de49d525b413da03a38414d1c3f78bd6b201ca92ce748f36296c7f149aa453dfd1dc2df28405e0629bda9c79529b3c7d84c9f84f631dbe2a33e8a
@@ -9596,6 +9596,7 @@ __metadata:
     "@types/jest": ^26.0.20
     "@types/lodash": ^4.14.168
     "@types/node": ^14.14.31
+    "@types/pdfjs-dist": ^2.1.7
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.1
     "@types/react-pdf": ^5.0.1


### PR DESCRIPTION
Lazily import all components of react-pdf within the pdf stepper-content component (skip SSR). Use import / then statement to load the pdf worker. In the MDX - tag to component mapping, import the pdf stepper-content component immediately. All in all, this effort reduces the page size where the MDX tag PDF gets used for about 70KB.