### PR TITLE
Refactor PDF worker integration

### DIFF
--- a/packages/app/components/src/pdf/PDFWorker.tsx
+++ b/packages/app/components/src/pdf/PDFWorker.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from 'react';
+import { pdfjs } from 'react-pdf';
+
+export const PDFWorker: FC = ({ children }) => {
+  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+  return <>{children}</>;
+};

--- a/packages/app/components/src/pdf/StepperContent.tsx
+++ b/packages/app/components/src/pdf/StepperContent.tsx
@@ -6,6 +6,13 @@ import { SizeMe } from 'react-sizeme';
 
 import { Stepper, TranslationProps } from '../stepper/Stepper';
 
+const PDFWorker = dynamic(
+  () => import('./PDFWorker').then(module => module.PDFWorker),
+  {
+    ssr: false
+  }
+);
+
 const Document = dynamic<DocumentProps>(
   () => import('react-pdf').then(module => module.Document),
   { ssr: false }
@@ -17,10 +24,6 @@ const Page = dynamic<PageProps>(
     ssr: false
   }
 );
-
-import('react-pdf').then(({ pdfjs }) => {
-  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
-});
 
 export type StepperContentWithTranslationProps = TranslationProps & {
   url: string;
@@ -58,12 +61,14 @@ export const StepperContent: FC<StepperContentWithTranslationProps> = ({
                 margin: '24px'
               }}
             >
-              <Document file={url} onLoadSuccess={onDocumentLoadSuccess}>
-                <Page
-                  pageNumber={step + 1}
-                  width={size.width ? size.width : 1}
-                />
-              </Document>
+              <PDFWorker>
+                <Document file={url} onLoadSuccess={onDocumentLoadSuccess}>
+                  <Page
+                    pageNumber={step + 1}
+                    width={size.width ? size.width : 1}
+                  />
+                </Document>
+              </PDFWorker>
             </div>
           )}
         </SizeMe>


### PR DESCRIPTION
Add dedicated component, and pass Document / Page children. Within the PDF worker component, assign the workerSrc.

Because now the component is a default react component, Nextjs dynamic import statement with the option SSR false is possible. Maybe this concept can be achieved using hooks using any async effect; one gets provided by the library @react-hook/async.

For now, the problem of undefined window objects gets solved. Another thought might be to encapsulate the PDF Viewer in a dedicated module to isolate the dependency chain down to pdf.js-dist, which react-pdf, of course, is using.