### PR TITLE
Centralize layout configuration

### DIFF
--- a/packages/app/layout/src/components/AppDrawer.tsx
+++ b/packages/app/layout/src/components/AppDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@app/components';
+import { MAX_DRAWER_WIDTH, MIN_DRAWER_WIDTH, TOOLBAR_HEIGHT } from '@app/layout/src/recoil/features/layout/reducer';
 import {
   createStyles,
   Divider,
@@ -7,7 +8,7 @@ import {
   makeStyles,
   SwipeableDrawer,
   Theme,
-  Typography
+  Typography,
 } from '@material-ui/core';
 import { ChevronLeft } from '@material-ui/icons';
 import clsx from 'clsx';
@@ -20,42 +21,36 @@ import { useRecoilValue } from 'recoil';
 import { navigationState } from '../recoil/features/pages/reducer';
 import { Tree } from './tree';
 
-const drawerWidth = 280;
-
 const useDrawerStyles = makeStyles((theme: Theme) =>
   createStyles({
     drawer: {
-      width: drawerWidth,
-      flexShrink: 0,
+      width: MAX_DRAWER_WIDTH,
       whiteSpace: 'nowrap'
     },
     drawerOpen: {
-      width: drawerWidth,
+      overflowX: 'hidden',
+      width: MAX_DRAWER_WIDTH,
       transition: theme.transitions.create('width', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.enteringScreen
       })
     },
     drawerClose: {
+      overflowX: 'hidden',
+      width: MIN_DRAWER_WIDTH,
       transition: theme.transitions.create('width', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.leavingScreen
-      }),
-      overflowX: 'hidden',
-      width: theme.spacing(7),
-      [theme.breakpoints.up('sm')]: {
-        width: theme.spacing(9)
-      }
+      })
     },
     toolbar: {
-      ...theme.mixins.toolbar,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-end',
-      padding: theme.spacing(0, 1)
+      minHeight: TOOLBAR_HEIGHT
     },
-    paper: {
-      width: drawerWidth
+    paperMobile: {
+      width: MAX_DRAWER_WIDTH
     }
   })
 );
@@ -95,7 +90,7 @@ export const AppDrawer: FC<AppDrawerProps> = ({
       <SwipeableDrawer
         variant='temporary'
         classes={{
-          paper: classes.paper
+          paper: classes.paperMobile
         }}
         disableBackdropTransition={!isIOS}
         open={isDrawerExpanded}
@@ -138,10 +133,7 @@ export const AppDrawer: FC<AppDrawerProps> = ({
           [classes.drawerClose]: !isDrawerExpanded
         })}
         classes={{
-          paper: clsx({
-            [classes.drawerOpen]: isDrawerExpanded,
-            [classes.drawerClose]: !isDrawerExpanded
-          })
+          paper: isDrawerExpanded ? classes.drawerOpen : classes.drawerClose
         }}
         open={isDrawerExpanded}
       >

--- a/packages/app/layout/src/components/AppFrame.tsx
+++ b/packages/app/layout/src/components/AppFrame.tsx
@@ -1,20 +1,22 @@
 import { Portal } from '@app/components';
+import { layoutState, MAX_DRAWER_WIDTH } from '@app/layout/src/recoil/features/layout/reducer';
 import { AppBar } from '@material-ui/core';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback } from 'react';
+import { useRecoilState } from 'recoil';
 
 import { AppDrawer } from './AppDrawer';
 import { AppToolBar } from './AppToolBar';
 import { HideOnScroll } from './HideOnScroll';
 
+// import dynamic from 'next/dynamic';
 // Warning - dynamic imports seem to destroy css server
 
-// import dynamic from 'next/dynamic';
 // import { AppDrawerProxy } from './AppDrawerProxy';
 // const AppDrawer = dynamic(() =>
-//   import('./AppDrawer').then(module => module.AppDrawer)
+//   import('./AppDrawerProxy').then(module => module.AppDrawerProxy)
 // );
 
 const useStyles = makeStyles(() =>
@@ -24,8 +26,6 @@ const useStyles = makeStyles(() =>
     }
   })
 );
-
-export const drawerWidth = 280;
 
 const useDrawerStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -37,8 +37,7 @@ const useDrawerStyles = makeStyles((theme: Theme) =>
       })
     },
     appBarShift: {
-      marginLeft: drawerWidth,
-      width: `calc(100% - ${drawerWidth}px)`,
+      width: `calc(100% - ${MAX_DRAWER_WIDTH}px)`,
       transition: theme.transitions.create(['width', 'margin'], {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.enteringScreen
@@ -55,14 +54,24 @@ export const AppFrame: FC<AppFrameProps> = ({ children, isMobile }) => {
   const classes = useStyles();
   const drawerClasses = useDrawerStyles();
 
-  const [isDrawerExpanded, setIsDrawerExpanded] = useState(false);
+  const [{ isDrawerExpanded }, setLayout] = useRecoilState(layoutState);
 
   const handleDrawerOpen = useCallback(() => {
-    setIsDrawerExpanded(true);
+    setLayout(state => {
+      return {
+        ...state,
+        isDrawerExpanded: true
+      };
+    });
   }, []);
 
   const handleDrawerClose = useCallback(() => {
-    setIsDrawerExpanded(false);
+    setLayout(state => {
+      return {
+        ...state,
+        isDrawerExpanded: false
+      };
+    });
   }, []);
 
   return (

--- a/packages/app/layout/src/components/AppToolBar.tsx
+++ b/packages/app/layout/src/components/AppToolBar.tsx
@@ -1,15 +1,10 @@
-import {
-  createStyles,
-  IconButton,
-  makeStyles,
-  Toolbar,
-  Tooltip
-} from '@material-ui/core';
+import { createStyles, IconButton, makeStyles, Theme, Toolbar, Tooltip } from '@material-ui/core';
 import { GitHub, Menu } from '@material-ui/icons';
 import clsx from 'clsx';
 import useTranslation from 'next-translate/useTranslation';
 import React, { FC } from 'react';
 
+import { TOOLBAR_HEIGHT } from '../recoil/features/layout/reducer';
 import { LanguageMenu } from './LanguageMenu';
 
 interface AppToolBarProps {
@@ -17,21 +12,17 @@ interface AppToolBarProps {
   handleDrawerOpen: () => void;
 }
 
-const useDrawerStyles = makeStyles(() =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    menuButton: {
-      marginRight: 36
+    toolbar: {
+      minHeight: TOOLBAR_HEIGHT,
+      padding: theme.spacing(0, 3)
+    },
+    grow: {
+      flex: '1 1 auto'
     },
     hide: {
       display: 'none'
-    }
-  })
-);
-
-const useStyles = makeStyles(() =>
-  createStyles({
-    grow: {
-      flex: '1 1 auto'
     }
   })
 );
@@ -40,19 +31,18 @@ export const AppToolBar: FC<AppToolBarProps> = ({
   isDrawerExpanded,
   handleDrawerOpen
 }) => {
-  const drawerClasses = useDrawerStyles();
   const classes = useStyles();
 
   const { t } = useTranslation();
 
   return (
-    <Toolbar>
+    <Toolbar className={classes.toolbar}>
       <IconButton
         edge='start'
         color='inherit'
         onClick={handleDrawerOpen}
-        className={clsx(drawerClasses.menuButton, {
-          [drawerClasses.hide]: isDrawerExpanded
+        className={clsx({
+          [classes.hide]: isDrawerExpanded
         })}
       >
         <Menu />

--- a/packages/app/layout/src/components/drawer/DesktopDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/DesktopDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@app/components';
+import { MAX_DRAWER_WIDTH, MIN_DRAWER_WIDTH, TOOLBAR_HEIGHT } from '@app/layout/src/recoil/features/layout/reducer';
 import { createStyles, Divider, Drawer, IconButton, makeStyles, Theme, Typography } from '@material-ui/core';
 import { ChevronLeft } from '@material-ui/icons';
 import clsx from 'clsx';
@@ -10,57 +11,33 @@ import { useRecoilValue } from 'recoil';
 import { navigationState } from '../../recoil/features/pages/reducer';
 import { Tree } from '../tree';
 
-const drawerWidth = 280;
-
 const useDrawerStyles = makeStyles((theme: Theme) =>
   createStyles({
     drawer: {
-      width: drawerWidth,
-      flexShrink: 0,
+      width: MAX_DRAWER_WIDTH,
       whiteSpace: 'nowrap'
     },
-
-    // drawer: {
-    //   [theme.breakpoints.up('lg')]: {
-    //     flexShrink: 0,
-    //     width: `${drawerWidth}px`
-    //   },
-    //   whiteSpace: 'nowrap'
-    // },
-
     drawerOpen: {
-      width: drawerWidth,
+      overflowX: 'hidden',
+      width: MAX_DRAWER_WIDTH,
       transition: theme.transitions.create('width', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.enteringScreen
       })
     },
     drawerClose: {
+      overflowX: 'hidden',
+      width: MIN_DRAWER_WIDTH,
       transition: theme.transitions.create('width', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.leavingScreen
-      }),
-      overflowX: 'hidden',
-      width: theme.spacing(7),
-      [theme.breakpoints.up('sm')]: {
-        width: theme.spacing(9)
-      }
+      })
     },
     toolbar: {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-end',
-      // at original
-      // padding: theme.spacing(0, 1),
-      padding: '0 8px',
-      ...theme.mixins.toolbar
-    },
-    toolbarTitle: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      padding: '0 8px',
-      ...theme.mixins.toolbar
+      minHeight: TOOLBAR_HEIGHT
     }
   })
 );
@@ -84,6 +61,16 @@ export const DesktopDrawer: FC<DesktopDrawerProps> = ({
 
   const { pages, activePage, flattenedPages } = navigation;
 
+  const treeComp =
+    activePage != null ? (
+      <Tree
+        pages={pages}
+        flattenedPages={flattenedPages}
+        pathname={asPath}
+        activePage={activePage}
+      />
+    ) : null;
+
   return pages && pages.length > 0 ? (
     <Drawer
       variant='permanent'
@@ -92,10 +79,7 @@ export const DesktopDrawer: FC<DesktopDrawerProps> = ({
         [classes.drawerClose]: !isDrawerExpanded
       })}
       classes={{
-        paper: clsx({
-          [classes.drawerOpen]: isDrawerExpanded,
-          [classes.drawerClose]: !isDrawerExpanded
-        })
+        paper: isDrawerExpanded ? classes.drawerOpen : classes.drawerClose
       }}
       open={isDrawerExpanded}
     >
@@ -108,9 +92,7 @@ export const DesktopDrawer: FC<DesktopDrawerProps> = ({
           }
           onClick={handleDrawerClose}
         >
-          <Typography variant='h6' className={classes.toolbarTitle}>
-            {t('common:application-title')}
-          </Typography>
+          <Typography variant='h6'>{t('common:application-title')}</Typography>
         </Link>
 
         <IconButton onClick={handleDrawerClose}>
@@ -118,12 +100,7 @@ export const DesktopDrawer: FC<DesktopDrawerProps> = ({
         </IconButton>
       </div>
       <Divider />
-      <Tree
-        pages={pages}
-        flattenedPages={flattenedPages}
-        pathname={asPath}
-        activePage={activePage}
-      />
+      {treeComp}
     </Drawer>
   ) : null;
 };

--- a/packages/app/layout/src/components/drawer/MobileDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/MobileDrawer.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@app/components';
-import { createStyles, Divider, IconButton, makeStyles, SwipeableDrawer, Theme, Typography } from '@material-ui/core';
+import { MAX_DRAWER_WIDTH, TOOLBAR_HEIGHT } from '@app/layout/src/recoil/features/layout/reducer';
+import { createStyles, Divider, IconButton, makeStyles, SwipeableDrawer, Typography } from '@material-ui/core';
 import { ChevronLeft } from '@material-ui/icons';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
@@ -9,42 +10,16 @@ import { useRecoilValue } from 'recoil';
 import { navigationState } from '../../recoil/features/pages/reducer';
 import { Tree } from '../tree';
 
-const drawerWidth = 280;
-
-const useDrawerStyles = makeStyles((theme: Theme) =>
+const useDrawerStyles = makeStyles(() =>
   createStyles({
-    drawer: {
-      [theme.breakpoints.up('lg')]: {
-        flexShrink: 0,
-        width: `${drawerWidth}px`
-      },
-      whiteSpace: 'nowrap'
-    },
-
-    // drawer: {
-    //   width: drawerWidth,
-    //   flexShrink: 0,
-    //   whiteSpace: 'nowrap'
-    // },
-
     toolbar: {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-end',
-      // at original
-      // padding: theme.spacing(0, 1),
-      padding: '0 8px'
-      //   ...theme.mixins.toolbar
+      minHeight: TOOLBAR_HEIGHT
     },
-    toolbarTitle: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      padding: '0 8px'
-      //   ...theme.mixins.toolbar
-    },
-    paper: {
-      width: drawerWidth
+    paperMobile: {
+      width: MAX_DRAWER_WIDTH
     }
   })
 );
@@ -70,11 +45,21 @@ export const MobileDrawer: FC<MobileDrawerProps> = ({
 
   const { pages, activePage, flattenedPages } = navigation;
 
+  const treeComp =
+    activePage != null ? (
+      <Tree
+        pages={pages}
+        flattenedPages={flattenedPages}
+        pathname={asPath}
+        activePage={activePage}
+      />
+    ) : null;
+
   return pages && pages.length > 0 ? (
     <SwipeableDrawer
       variant='temporary'
       classes={{
-        paper: classes.paper
+        paper: classes.paperMobile
       }}
       open={isDrawerExpanded}
       onClose={handleDrawerClose}
@@ -92,22 +77,16 @@ export const MobileDrawer: FC<MobileDrawerProps> = ({
           }
           onClick={handleDrawerClose}
         >
-          <Typography variant='h6' className={classes.toolbarTitle}>
-            {t('common:application-title')}
-          </Typography>
+          <Typography variant='h6'>{t('common:application-title')}</Typography>
         </Link>
 
         <IconButton onClick={handleDrawerClose}>
           <ChevronLeft />
         </IconButton>
       </div>
+
       <Divider />
-      <Tree
-        pages={pages}
-        flattenedPages={flattenedPages}
-        pathname={asPath}
-        activePage={activePage}
-      />
+      {treeComp}
     </SwipeableDrawer>
   ) : null;
 };

--- a/packages/app/layout/src/components/tree/Tree.tsx
+++ b/packages/app/layout/src/components/tree/Tree.tsx
@@ -84,15 +84,9 @@ const StyledTreeItem: FC<TreeItemProps> = props => {
 
 const useStylesTreeLabel = makeStyles((theme: Theme) =>
   createStyles({
-    listItemPadding: {
-      [theme.breakpoints.down('xs')]: {
-        paddingLeft: '16px',
-        paddingRight: '16px'
-      },
-      [theme.breakpoints.up('sm')]: {
-        paddingLeft: '24px',
-        paddingRight: '24px'
-      }
+    listItem: {
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3)
     }
   })
 );
@@ -119,7 +113,7 @@ const TreeLabel: FC<TreeLabelProps> = ({
   }
 
   return (
-    <ListItem button className={classes.listItemPadding}>
+    <ListItem button className={classes.listItem}>
       <ListItemIcon>{getIconByName(icon.name)}</ListItemIcon>
       <ListItemText secondary={labelText} />
       {renderExpand}

--- a/packages/app/layout/src/recoil/features/layout/reducer.ts
+++ b/packages/app/layout/src/recoil/features/layout/reducer.ts
@@ -1,0 +1,25 @@
+import { atom } from 'recoil';
+
+// TOOLBAR
+export const TOOLBAR_HEIGHT = 64;
+
+// TABLE OF CONTENTS
+export const TOC_TOP = 96;
+export const TOC_WIDTH = 225;
+
+// DRAWER
+export const MIN_DRAWER_WIDTH = 72;
+export const MAX_DRAWER_WIDTH = 280;
+
+export interface Layout {
+  isDrawerExpanded: boolean;
+}
+
+export const initialState: Layout = {
+  isDrawerExpanded: false
+};
+
+export const layoutState = atom({
+  key: 'layout',
+  default: initialState
+});

--- a/packages/page/layout/src/components/AppContent.tsx
+++ b/packages/page/layout/src/components/AppContent.tsx
@@ -1,43 +1,48 @@
+import { layoutState, MAX_DRAWER_WIDTH, MIN_DRAWER_WIDTH, TOC_WIDTH } from '@app/layout/src/recoil/features/layout/reducer';
 import { Container, createStyles, makeStyles, Theme } from '@material-ui/core';
-import clsx from 'clsx';
 import React, { FC } from 'react';
+import { useRecoilValue } from 'recoil';
 
 interface AppContentProps {
-  disableToc?: boolean;
+  disableToc: boolean;
 }
 
-const useStyles = makeStyles((theme: Theme) =>
+interface StyleProps {
+  drawerWidth: number;
+  tocWidth: number;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) =>
   createStyles({
     root: {
       paddingTop: theme.spacing(12),
-      outline: 'none',
+
+      // hyphen
+      msHyphens: 'auto',
+      WebkitHyphens: 'auto',
+      MozHyphens: 'auto',
       hyphens: 'auto',
-      '-ms-hyphens': 'auto',
-      '-moz-hyphens': 'auto',
-      '-webkit-hyphens': 'auto'
-    },
-    disableToc: {
-      [theme.breakpoints.up('sm')]: {
-        maxWidth: 'calc(100%)'
+
+      [theme.breakpoints.down('md')]: {
+        width: props => `calc(100% - ${props.drawerWidth}px`
       },
       [theme.breakpoints.up('lg')]: {
-        maxWidth: 'calc(100% - 280px)'
+        width: props =>
+          `calc(100% - ${props.drawerWidth}px - ${props.tocWidth}px )`
       }
     }
   })
 );
+export const AppContent: FC<AppContentProps> = ({ disableToc, children }) => {
+  const { isDrawerExpanded } = useRecoilValue(layoutState);
 
-export const AppContent: FC<AppContentProps> = ({ children, disableToc }) => {
-  const classes = useStyles();
+  const classes = useStyles({
+    drawerWidth: isDrawerExpanded ? MAX_DRAWER_WIDTH : MIN_DRAWER_WIDTH,
+    tocWidth: !disableToc ? TOC_WIDTH : 0
+  });
 
   return (
-    <Container
-      component='main'
-      id='main-content'
-      className={clsx(classes.root, {
-        [classes.disableToc]: disableToc
-      })}
-    >
+    <Container component='main' id='main-content' className={classes.root}>
       {children}
     </Container>
   );

--- a/packages/page/layout/src/components/AppContentMobile.tsx
+++ b/packages/page/layout/src/components/AppContentMobile.tsx
@@ -1,0 +1,27 @@
+import { Container, createStyles, makeStyles, Theme } from '@material-ui/core';
+import React, { FC } from 'react';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      paddingTop: theme.spacing(12),
+      outline: 'none',
+
+      // hyphen
+      msHyphens: 'auto',
+      MozHyphens: 'auto',
+      WebkitHyphens: 'auto',
+      hyphens: 'auto'
+    }
+  })
+);
+
+export const AppContentMobile: FC = ({ children }) => {
+  const classes = useStyles();
+
+  return (
+    <Container component='main' id='main-content' className={classes.root}>
+      {children}
+    </Container>
+  );
+};

--- a/packages/page/layout/src/components/AppTableOfContents.tsx
+++ b/packages/page/layout/src/components/AppTableOfContents.tsx
@@ -1,24 +1,23 @@
+import { TOC_TOP, TOC_WIDTH } from '@app/layout/src/recoil/features/layout/reducer';
 import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
 import useTranslation from 'next-translate/useTranslation';
 import React, { FC } from 'react';
 
 import { TocComponent } from './toc';
 
-export const WIDTH_TOC = 225;
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      width: WIDTH_TOC,
-      top: 96,
+      width: TOC_WIDTH,
+      top: TOC_TOP,
       order: 2,
       flexShrink: 0,
       position: 'sticky',
-      height: 'calc(100% - 96px)',
+      height: `calc(100% - ${TOC_TOP}px)`,
       margin: theme.spacing(1),
       overflowY: 'auto',
       display: 'none',
-      [theme.breakpoints.up('sm')]: {
+      [theme.breakpoints.up('md')]: {
         display: 'block'
       },
       '& ul': {

--- a/packages/page/layout/src/mdx/MdxDocsMobile.tsx
+++ b/packages/page/layout/src/mdx/MdxDocsMobile.tsx
@@ -2,8 +2,8 @@ import { PageTypes } from '@app/types';
 import { Snackbar } from '@page/components';
 import React, { FC } from 'react';
 
-import { AppContent } from '../components/AppContent';
 import { AppContentFooter } from '../components/AppContentFooter';
+import { AppContentMobile } from '../components/AppContentMobile';
 import { AppHead } from '../components/AppHead';
 import { useMdxStyles } from './MDXStyles';
 
@@ -17,7 +17,7 @@ export const MdxDocsMobile: FC<MarkdownDocsProps> = ({ meta, children }) => {
   return (
     <>
       <AppHead meta={meta} />
-      <AppContent disableToc>
+      <AppContentMobile>
         {children && (
           <div className={classes.root}>
             {children}
@@ -25,7 +25,7 @@ export const MdxDocsMobile: FC<MarkdownDocsProps> = ({ meta, children }) => {
             <AppContentFooter />
           </div>
         )}
-      </AppContent>
+      </AppContentMobile>
     </>
   );
 };


### PR DESCRIPTION
- Introduce a central configuration that defines layout defaults.
- Simplify styles due to a layout shift when the "sm" breakpoint gets hit. See previous app drawer styles;
For now, both mobile and desktop variants share the same width for drawer items and the toolbar expander/collapse button.
- The value if the drawer got expanded or collapsed gets persisted in a recoil atom.
- Remove unused styles.