### PR TITLE
Refactor top reveal animation

### DIFF
--- a/packages/page/landing/src/animation/framer/components/text/TopReveal.tsx
+++ b/packages/page/landing/src/animation/framer/components/text/TopReveal.tsx
@@ -1,27 +1,31 @@
 import { StringUtil } from '@app/utils';
 import { Typography } from '@material-ui/core';
-import { motion, Variants } from 'framer-motion';
+import { AnimatePresence, motion, Variants } from 'framer-motion';
 import isArray from 'lodash/isArray';
 import React from 'react';
 
 interface TopRevealProps {
   id: string;
   text: Array<string> | string;
-
-  fontColor?: string;
-
   // input parameters for height calculation
   lineGap?: number;
   fontSize?: number;
-
+  fontColor?: string;
   // animation property
   stagger?: number;
   loop?: boolean;
-  outerIndex: number;
 }
 
 export const TopReveal = (props: TopRevealProps) => {
-  const { lineGap, fontSize, fontColor, stagger, text, id, loop } = props;
+  const {
+    id,
+    text,
+    lineGap = 0,
+    fontSize = 24,
+    fontColor = '#000000',
+    stagger = 0.3,
+    loop = true
+  } = props;
 
   const items = isArray(text) ? text : StringUtil.stringToArray(text);
 
@@ -33,8 +37,8 @@ export const TopReveal = (props: TopRevealProps) => {
 
   // Add staggering effect to the children of the line container
   const lineContainerVariants = {
-    before: {},
-    after: { transition: { delayChildren: stagger * items.length } }
+    before: { transition: { delayChildren: stagger } },
+    after: {}
   };
 
   // Variants for animating the text
@@ -80,86 +84,71 @@ export const TopReveal = (props: TopRevealProps) => {
   };
 
   return (
-    <motion.div
-      key={id}
-      style={{
-        size: '100%',
-        background: '',
-        position: 'relative'
-      }}
-    >
+    <AnimatePresence>
       <motion.div
+        key={id}
         style={{
-          width: '100%',
-          height: (fontSize * 1.5 + lineGap) * items.length * 2 + 24
+          position: 'relative'
         }}
-        initial={'before'}
-        animate={'after'}
-        variants={containerVariants}
       >
-        {items.map((item, i) => {
-          return (
-            <motion.div
-              key={i}
-              style={{
-                width: '100%',
-                height: fontSize * 1.5,
-                y: (fontSize * 1.5 + lineGap) * i,
-                overflow: 'hidden'
-              }}
-            >
-              <motion.div
-                style={{
-                  size: '100%',
-                  fontSize,
-                  color: fontColor
-                }}
-                variants={textVariants}
-              >
-                <Typography variant='h3' style={{ fontSize: '24px' }}>
-                  {item}
-                </Typography>
-              </motion.div>
-            </motion.div>
-          );
-        })}
         <motion.div
           style={{
-            size: '100%'
+            width: '100%',
+            height: (fontSize * 1.5 + lineGap) * items.length * 2 + 24
           }}
-          variants={lineContainerVariants}
+          initial={'before'}
+          animate={'after'}
+          variants={containerVariants}
         >
-          <motion.div
-            style={{
-              position: 'absolute',
-              height: '10px',
-              y: (fontSize * 1.5 + lineGap) * items.length + 10,
-              left: '50%',
-              backgroundColor: 'grey'
-            }}
-            variants={lineVariants}
-          />
-          <motion.div
-            style={{
-              position: 'absolute',
-              height: '10px',
-              y: (fontSize * 1.5 + lineGap) * items.length + 10,
-              right: '50%',
-              backgroundColor: 'grey'
-            }}
-            variants={lineVariants}
-          />
+          {items.map((item, i) => {
+            return (
+              <motion.div
+                key={i}
+                style={{
+                  width: '100%',
+                  height: fontSize * 1.5,
+                  y: (fontSize * 1.5 + lineGap) * i,
+                  overflow: 'hidden'
+                }}
+              >
+                <motion.div
+                  style={{
+                    fontSize,
+                    color: fontColor
+                  }}
+                  variants={textVariants}
+                >
+                  <Typography variant='h3' style={{ fontSize: '24px' }}>
+                    {item}
+                  </Typography>
+                </motion.div>
+              </motion.div>
+            );
+          })}
+          <motion.div variants={lineContainerVariants}>
+            <motion.div
+              style={{
+                position: 'absolute',
+                height: '10px',
+                y: (fontSize * 1.5 + lineGap) * items.length + 10,
+                left: '50%',
+                backgroundColor: 'grey'
+              }}
+              variants={lineVariants}
+            />
+            <motion.div
+              style={{
+                position: 'absolute',
+                height: '10px',
+                y: (fontSize * 1.5 + lineGap) * items.length + 10,
+                right: '50%',
+                backgroundColor: 'grey'
+              }}
+              variants={lineVariants}
+            />
+          </motion.div>
         </motion.div>
       </motion.div>
-    </motion.div>
+    </AnimatePresence>
   );
-};
-
-TopReveal.defaultProps = {
-  width: 200,
-  lineGap: 0,
-  fontSize: 24,
-  fontColor: '#000000',
-  stagger: 0.3,
-  loop: true
 };

--- a/packages/page/landing/src/components/Topics.tsx
+++ b/packages/page/landing/src/components/Topics.tsx
@@ -78,7 +78,7 @@ export const Topics: FC<TopicsProps> = ({ feature, aspect }) => {
                     {categoryData.map((data, index) => {
                       const { title, description, link, icon } = data;
                       return (
-                        <Grid key={index} item xs={12} md={6}>
+                        <Grid item key={index} xs={12} md={6}>
                           <Item
                             title={title}
                             description={description}

--- a/packages/page/landing/src/components/TopicsViewDesktop.tsx
+++ b/packages/page/landing/src/components/TopicsViewDesktop.tsx
@@ -67,24 +67,21 @@ export const TopicsViewDesktop: FC<TopicsViewDesktopProps> = ({ topics }) => {
 
   return (
     <Grid container>
-      {topics.length > 0
+      {topics && topics.length > 0
         ? topics.map((topic, index) => {
             return (
               <Grid
-                key={`topic-${index}`}
                 item
+                key={`topic-${index}`}
                 xs={12}
                 md={index <= 1 ? 6 : 12}
               >
                 <div className={classes.container}>
-                  <div className={classes.container}>
-                    <TopReveal
-                      id={`animation-${index}`}
-                      text={[...topic.title, ...topic.subTitle]}
-                      outerIndex={0}
-                      loop={false}
-                    />
-                  </div>
+                  <TopReveal
+                    id={`animation-${index}`}
+                    text={[...topic.title, ...topic.subTitle]}
+                    loop={false}
+                  />
                   <div className={classes.container}>
                     {topic.contextLink
                       ? topic.contextLink.sections.map((section, index) => {

--- a/packages/page/landing/src/interface/FullScreenInterfaceByComponent/index.tsx
+++ b/packages/page/landing/src/interface/FullScreenInterfaceByComponent/index.tsx
@@ -1,13 +1,7 @@
 import { ContentTypes } from '@app/types';
 import React, { FC } from 'react';
-import styled from 'styled-components';
 
 import Window from '../windowByComponent';
-
-const Container = styled.div`
-  height: 100%;
-  width: 100%;
-`;
 
 export interface FullScreenInterfaceProps {
   windowStackData?: Array<ContentTypes.OverviewProps>;
@@ -19,12 +13,10 @@ export const FullScreenInterface: FC<FullScreenInterfaceProps> = ({
   index
 }) => {
   return (
-    <Container>
-      <Window
-        key={`window-${windowStackData ? windowStackData.length : 0}-${index}`}
-        windowStackData={windowStackData}
-        index={index}
-      />
-    </Container>
+    <Window
+      key={`window-${windowStackData ? windowStackData.length : 0}-${index}`}
+      windowStackData={windowStackData}
+      index={index}
+    />
   );
 };

--- a/packages/page/landing/src/interface/windowByComponent.tsx
+++ b/packages/page/landing/src/interface/windowByComponent.tsx
@@ -1,15 +1,10 @@
 import { CustomIcon } from '@app/components';
 import { ContentTypes } from '@app/types';
 import { createStyles, IconButton, makeStyles, Theme } from '@material-ui/core';
-import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import React, { FC } from 'react';
-import styled from 'styled-components';
 
-import { noAnimation } from '../animation';
 import { TopReveal } from '../animation/framer/components/text/TopReveal';
-
-export const AnimationContainer = styled(motion.div)``;
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -46,35 +41,31 @@ const Window: FC<WindowProps> = ({ windowStackData, index }) => {
     });
   };
 
-  const topic = windowStackData[index];
+  const topic =
+    windowStackData && windowStackData.length >= index
+      ? windowStackData[index]
+      : {};
 
-  return windowStackData != null && windowStackData.length > 0 ? (
+  return topic != null ? (
     <div className={classes.container}>
+      <TopReveal
+        id={`animation-${index}`}
+        text={[...topic.title, ...topic.subTitle]}
+      />
       <div className={classes.container}>
-        <AnimationContainer key={`topic-${index}`} {...noAnimation}>
-          <TopReveal
-            id={`animation-${index}`}
-            key={`animation-${index}`}
-            text={[...topic.title, ...topic.subTitle]}
-            outerIndex={index}
-          />
-        </AnimationContainer>
-      </div>
-      <div className={classes.container}>
-        {topic.contextLink
-          ? topic.contextLink.sections.map((section, index) => {
-              return (
-                <IconButton
-                  key={`section-${index}`}
-                  onClick={_e => {
-                    handleSelect(topic, section);
-                  }}
-                >
-                  <CustomIcon icon={section.icon} />
-                </IconButton>
-              );
-            })
-          : null}
+        {topic.contextLink &&
+          topic.contextLink.sections.map((section, index) => {
+            return (
+              <IconButton
+                key={`section-${index}`}
+                onClick={_e => {
+                  handleSelect(topic, section);
+                }}
+              >
+                <CustomIcon icon={section.icon} />
+              </IconButton>
+            );
+          })}
       </div>
     </div>
   ) : null;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,13 @@ import { Components } from '@page/layout';
 import { GetStaticPropsContext } from 'next';
 import loadNamespaces from 'next-translate/loadNamespaces';
 import useTranslation from 'next-translate/useTranslation';
+import dynamic from 'next/dynamic';
 import React, { FC } from 'react';
+
+const TopicsHead = dynamic(
+  () => import('@page/landing').then(module => module.Components.TopicsHead),
+  { ssr: false }
+);
 
 loadFAIcons();
 
@@ -51,7 +57,8 @@ const Index: FC = () => {
           <Typography variant='h4' gutterBottom className={classes.subtitle}>
             {t('common:application-subtitle')}
           </Typography>
-          <ComponentsLanding.TopicsHead />
+
+          <TopicsHead />
           <ComponentsLanding.TopicsDetail />
 
           <Components.HomeFooter />


### PR DESCRIPTION
Render the topics-head animation on the client exclusively. Add animation presence, only within use motion. Change line container Variant, switch before and after statements. Remove static default-props. Remove wrapper components that had no effect.