### PR TITLE
Simplify i18n integration

### DIFF
--- a/docs/src/lib/getStaticTranslationProps.tsx
+++ b/docs/src/lib/getStaticTranslationProps.tsx
@@ -3,6 +3,8 @@ import { GetStaticPropsContext } from 'next';
 import loadNamespaces from 'next-translate/loadNamespaces';
 import path from 'path';
 
+import i18nConfig from '../../../i18n';
+
 export interface GetStaticTranslationProps {
   __lang?: string;
   __namespaces?: { [key: string]: object };
@@ -27,8 +29,9 @@ export const getStaticTranslationProps = ({
   const pathNoExt = isArray(slug) ? slug.join(path.sep) || '.' : slug;
 
   const namespaces = await loadNamespaces({
-    ...ctx,
-    pathname: `/${pathNoExt}`
+    ...i18nConfig,
+    pathname: `/${pathNoExt}`,
+    locale: locale
   });
   if (namespaces && onSuccess) {
     onSuccess(namespaces);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,48 +3,44 @@ import { Portal, Query } from '@app/components';
 import { HouxProvider } from '@app/houx';
 import { AppFrame, AppWrapper } from '@app/layout';
 import { NextComponentType } from 'next';
-import appWithI18n from 'next-translate/appWithI18n';
+import I18nProvider from 'next-translate/I18nProvider';
 import { AppContext, AppInitialProps, AppProps } from 'next/app';
 import React, { useEffect } from 'react';
-import { isMobile } from 'react-device-detect';
 import { RecoilRoot } from 'recoil';
 import { AnalyticsProvider } from 'use-analytics';
 
-import i18nConfig from '../i18n';
+const MillipedeApp: NextComponentType<AppContext, AppInitialProps, AppProps> =
+  ({ Component, pageProps }) => {
+    useEffect(() => {
+      // Remove the server-side injected CSS.
+      const jssStyles = document.querySelector('#jss-server-side');
+      if (jssStyles) {
+        jssStyles.parentNode.removeChild(jssStyles);
+      }
+    }, []);
 
-const MillipedeApp: NextComponentType<
-  AppContext,
-  AppInitialProps,
-  AppProps
-> = ({ Component, pageProps }) => {
-  useEffect(() => {
-    // Remove the server-side injected CSS.
-    const jssStyles = document.querySelector('#jss-server-side');
-    if (jssStyles) {
-      jssStyles.parentNode.removeChild(jssStyles);
-    }
-  }, []);
+    return (
+      <AnalyticsProvider instance={defaultAnalytics}>
+        <Query.QueryParamProvider>
+          <Portal.PortalProvider>
+            <RecoilRoot>
+              <HouxProvider>
+                <I18nProvider
+                  lang={pageProps && pageProps.__lang}
+                  namespaces={pageProps && pageProps.__namespaces}
+                >
+                  <AppWrapper>
+                    <AppFrame>
+                      <Component {...pageProps} />
+                    </AppFrame>
+                  </AppWrapper>
+                </I18nProvider>
+              </HouxProvider>
+            </RecoilRoot>
+          </Portal.PortalProvider>
+        </Query.QueryParamProvider>
+      </AnalyticsProvider>
+    );
+  };
 
-  return (
-    <AnalyticsProvider instance={defaultAnalytics}>
-      <Query.QueryParamProvider>
-        <Portal.PortalProvider>
-          <RecoilRoot>
-            <HouxProvider>
-              <AppWrapper>
-                <AppFrame isMobile={isMobile}>
-                  <Component {...pageProps} />
-                </AppFrame>
-              </AppWrapper>
-            </HouxProvider>
-          </RecoilRoot>
-        </Portal.PortalProvider>
-      </Query.QueryParamProvider>
-    </AnalyticsProvider>
-  );
-};
-
-export default appWithI18n(MillipedeApp, {
-  ...i18nConfig,
-  skipInitialProps: true
-});
+export default MillipedeApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,8 @@ import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 import React, { FC } from 'react';
 
+import i18nConfig from '../i18n';
+
 const TopicsHead = dynamic(
   () => import('@page/landing').then(module => module.Components.TopicsHead),
   { ssr: false }
@@ -68,11 +70,14 @@ const Index: FC = () => {
   );
 };
 
-export const getStaticProps = async (context: GetStaticPropsContext) => {
+export const getStaticProps = async (ctx: GetStaticPropsContext) => {
+  const { locale } = ctx;
+
   return {
     props: await loadNamespaces({
-      ...context,
-      pathname: '/'
+      ...i18nConfig,
+      pathname: '/',
+      locale: locale
     })
   };
 };


### PR DESCRIPTION
Do not wrap the app in the higher-order component appWithI18n anymore; instead, use the I18nProvider. The providers' values get served from the getStaticProps function integrated into the index page and any dynamic page / [...slug]. See getStaticTranslationProps function, which loads required namespaces due to the current navigation path.