### PR TITLE
Refactor structure loading of content components

### DIFF
--- a/docs/src/lib/getContent.tsx
+++ b/docs/src/lib/getContent.tsx
@@ -4,19 +4,13 @@ import fg from 'fast-glob';
 import fs from 'fs';
 import isArray from 'lodash/isArray';
 import { GetStaticPropsContext } from 'next';
-import dynamic from 'next/dynamic';
 import path from 'path';
+import { isMobile } from 'react-device-detect';
 import remarkSlug from 'remark-slug';
 
 import { getComponents, getHydrationComponentsList } from './getComponents';
 import { getMetadata } from './getMetadata';
 import { getPageDirectory } from './pages';
-
-const h2 = dynamic(() => import('@page/layout').then(module => module.Mdx.h2));
-const h3 = dynamic(() => import('@page/layout').then(module => module.Mdx.h3));
-const h4 = dynamic(() => import('@page/layout').then(module => module.Mdx.h4));
-const h5 = dynamic(() => import('@page/layout').then(module => module.Mdx.h5));
-const h6 = dynamic(() => import('@page/layout').then(module => module.Mdx.h6));
 
 const fsPromises = fs.promises;
 
@@ -55,11 +49,11 @@ export const getContent = async (
     components: {
       ...getComponents(hydrationComponentsList),
       h1: Mdx.h1({ disableShare, meta: restMetaData }),
-      h2,
-      h3,
-      h4,
-      h5,
-      h6
+      h2: Mdx.h2({ isMobile: isMobile }),
+      h3: Mdx.h3({ isMobile: isMobile }),
+      h4: Mdx.h4({ isMobile: isMobile }),
+      h5: Mdx.h5,
+      h6: Mdx.h6
     },
     compileOptions: {
       remarkPlugins: [remarkSlug],

--- a/packages/page/layout/src/components/AppContentMobile.tsx
+++ b/packages/page/layout/src/components/AppContentMobile.tsx
@@ -20,7 +20,11 @@ export const AppContentMobile: FC = ({ children }) => {
   const classes = useStyles();
 
   return (
-    <Container component='main' id='main-content' className={classes.root}>
+    <Container
+      component='main'
+      id='main-mobile-content'
+      className={classes.root}
+    >
       {children}
     </Container>
   );

--- a/packages/page/layout/src/mdx/MdxElement.tsx
+++ b/packages/page/layout/src/mdx/MdxElement.tsx
@@ -4,7 +4,6 @@ import { createStyles, makeStyles, Typography } from '@material-ui/core';
 import { Components } from '@page/layout';
 import dynamic from 'next/dynamic';
 import React, { FC, ReactNode } from 'react';
-import { isMobile } from 'react-device-detect';
 
 const Share = dynamic(() =>
   import('@page/components').then(module => module.Share)
@@ -18,6 +17,7 @@ interface MDXProps {
 interface MDXRenderProps {
   disableShare?: boolean;
   meta?: PageTypes.ContentMetaData;
+  isMobile?: boolean;
 }
 
 export const useStyles = makeStyles(() =>
@@ -41,32 +41,41 @@ export const h1 = ({ disableShare, meta }: MDXRenderProps) => {
   };
 };
 
-export const h2: FC<MDXProps> = ({ children, id }) =>
-  isMobile ? (
-    <Typography variant='h2'>{children}</Typography>
-  ) : (
-    <Components.Head.InteractiveHead variant='h2' id={id}>
-      {children}
-    </Components.Head.InteractiveHead>
-  );
+export const h2 = ({ isMobile }: MDXRenderProps) => {
+  return ({ children, id }: MDXProps) => {
+    return isMobile ? (
+      <Typography variant='h2'>{children}</Typography>
+    ) : (
+      <Components.Head.InteractiveHead variant='h2' id={id}>
+        {children}
+      </Components.Head.InteractiveHead>
+    );
+  };
+};
 
-export const h3: FC<MDXProps> = ({ children, id }) =>
-  isMobile ? (
-    <Typography variant='h3'>{children}</Typography>
-  ) : (
-    <Components.Head.InteractiveHead variant='h3' id={id}>
-      {children}
-    </Components.Head.InteractiveHead>
-  );
+export const h3 = ({ isMobile }: MDXRenderProps) => {
+  return ({ children, id }: MDXProps) => {
+    return isMobile ? (
+      <Typography variant='h3'>{children}</Typography>
+    ) : (
+      <Components.Head.InteractiveHead variant='h3' id={id}>
+        {children}
+      </Components.Head.InteractiveHead>
+    );
+  };
+};
 
-export const h4: FC<MDXProps> = ({ children, id }) =>
-  isMobile ? (
-    <Typography variant='h4'>{children}</Typography>
-  ) : (
-    <Components.Head.InteractiveHead variant='h4' id={id}>
-      {children}
-    </Components.Head.InteractiveHead>
-  );
+export const h4 = ({ isMobile }: MDXRenderProps) => {
+  return ({ children, id }: MDXProps) => {
+    return isMobile ? (
+      <Typography variant='h4'>{children}</Typography>
+    ) : (
+      <Components.Head.InteractiveHead variant='h4' id={id}>
+        {children}
+      </Components.Head.InteractiveHead>
+    );
+  };
+};
 
 export const h5: FC<MDXProps> = ({ children }) => (
   <Typography variant='h5'>{children}</Typography>

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -11,18 +11,14 @@ import { getPath } from '../../docs/src/lib/getPath';
 import { GetStaticContentProps, getStaticContentProps } from '../../docs/src/lib/getStaticContentProps';
 import { GetStaticTranslationProps, getStaticTranslationProps } from '../../docs/src/lib/getStaticTranslationProps';
 
-const MdxDocs = dynamic(() =>
-  import('@page/layout').then(module => module.Mdx.MdxDocs)
+const MdxDocs = dynamic(
+  () => import('@page/layout').then(module => module.Mdx.MdxDocs),
+  { ssr: false }
 );
-const MdxDocsMobile = dynamic(() =>
-  import('@page/layout').then(module => module.Mdx.MdxDocsMobile)
+const MdxDocsMobile = dynamic(
+  () => import('@page/layout').then(module => module.Mdx.MdxDocsMobile),
+  { ssr: false }
 );
-
-const h2 = dynamic(() => import('@page/layout').then(module => module.Mdx.h2));
-const h3 = dynamic(() => import('@page/layout').then(module => module.Mdx.h3));
-const h4 = dynamic(() => import('@page/layout').then(module => module.Mdx.h4));
-const h5 = dynamic(() => import('@page/layout').then(module => module.Mdx.h5));
-const h6 = dynamic(() => import('@page/layout').then(module => module.Mdx.h6));
 
 type DynamicPageProps = GetStaticTranslationProps & GetStaticContentProps;
 
@@ -40,11 +36,11 @@ const DynamicPage: FC<DynamicPageProps> = ({
     components: {
       ...getComponents(hydrationComponentsList),
       h1: Mdx.h1({ disableShare, meta: restMetaData }),
-      h2,
-      h3,
-      h4,
-      h5,
-      h6
+      h2: Mdx.h2({ isMobile: isMobile }),
+      h3: Mdx.h3({ isMobile: isMobile }),
+      h4: Mdx.h4({ isMobile: isMobile }),
+      h5: Mdx.h5,
+      h6: Mdx.h6
     },
     scope
   });


### PR DESCRIPTION
Load MDX (mobile) document structure without SSR because it is unclear if the user is on a mobile device or not. Load atomic components such as h1 - h6 depend on whether they have to be interactive or not and the device used. Do component loading in both getContent / getStaticContentProps / getStaticProps respectively in the dynamic page render.