### PR TITLE
Onboard navigation feature

### DIFF
--- a/packages/demonstrator/navigation/package.json
+++ b/packages/demonstrator/navigation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@demonstrator/navigation",
+  "version": "0.2.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "devDependencies": {
+    "@types/react-reconciler": "^0.26.1",
+    "typescript": "^4.1.5"
+  },
+  "dependencies": {
+    "react-reparenting": "^0.6.1"
+  }
+}

--- a/packages/demonstrator/navigation/src/components/BottomNavigationControl.tsx
+++ b/packages/demonstrator/navigation/src/components/BottomNavigationControl.tsx
@@ -1,0 +1,44 @@
+import { BottomNavigation, BottomNavigationAction } from '@material-ui/core';
+import RestoreIcon from '@material-ui/icons/Restore';
+import React, { ChangeEvent, FC, useCallback } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { useNavigation } from '../hooks/useNavigation';
+import { activeViewIdSelector, viewNavigationState } from '../recoil/features/view-navigation/reducers';
+import { TViewElement } from '../types';
+
+export const BottomNavigationControl: FC = () => {
+  const { viewElements } = useRecoilValue(viewNavigationState);
+
+  const [{ id: activeViewElementId }] = useRecoilValue(activeViewIdSelector);
+
+  const navigate = useNavigation();
+
+  const handleNavigationChange = useCallback(
+    (_event: ChangeEvent, newActiveViewElementId: string) => {
+      navigate(activeViewElementId, newActiveViewElementId);
+    },
+    [navigate, activeViewElementId]
+  );
+
+  const renderView = (viewElement: TViewElement) => {
+    return (
+      <BottomNavigationAction
+        key={`bna-${viewElement.id}`}
+        label={viewElement.label}
+        value={viewElement.id}
+        icon={<RestoreIcon />}
+      />
+    );
+  };
+
+  return (
+    <BottomNavigation
+      value={activeViewElementId}
+      onChange={handleNavigationChange}
+      showLabels
+    >
+      {viewElements.map(renderView)}
+    </BottomNavigation>
+  );
+};

--- a/packages/demonstrator/navigation/src/components/Navigation.svc.ts
+++ b/packages/demonstrator/navigation/src/components/Navigation.svc.ts
@@ -1,0 +1,91 @@
+import isArray from 'lodash/isArray';
+import { nanoid } from 'nanoid';
+
+import { FlattenedPartialViewElement, PartialViewElement, TPosition, TView } from '../types';
+import { Position } from '../types/View';
+
+export const generateViews = (size: number, position: TPosition) => {
+  return Array.from<any, TView>({ length: size }, () => ({
+    id: nanoid(),
+    position
+  }));
+};
+
+export const createViews = (
+  viewElements: Array<FlattenedPartialViewElement>
+): [Array<TView>, TView, Array<TView>] => {
+  const viewsToGenerate =
+    viewElements.filter(viewElement => viewElement.isParent).length - 1;
+
+  const initialMiddleView: TView = {
+    id: nanoid(),
+    position: Position.middle
+  };
+
+  const initialLeftViews = generateViews(viewsToGenerate, Position.left);
+  const initialRightViews = generateViews(viewsToGenerate, Position.right);
+
+  return [initialLeftViews, initialMiddleView, initialRightViews];
+};
+
+export const createViewElements = (
+  viewElements: Array<FlattenedPartialViewElement>,
+  views: Array<TView>
+) => {
+  let restViews: Array<TView> = [];
+
+  const connectedViewElements = viewElements.reduce<
+    Array<FlattenedPartialViewElement>
+  >((acc, viewElement) => {
+    if (!viewElement.isParent) {
+      const currentViewElement = acc.find(currentViewElement => {
+        const siblingViewElementIds = currentViewElement.siblings.map(
+          sibling => sibling.id
+        );
+        return siblingViewElementIds.includes(viewElement.id);
+      });
+      return [
+        ...acc,
+        { ...viewElement, parentId: currentViewElement.parentId }
+      ];
+    } else {
+      const [first, ...rest] = restViews.length > 0 ? restViews : views;
+      restViews = rest;
+      return [...acc, { ...viewElement, parentId: first.id }];
+    }
+  }, []);
+  return connectedViewElements;
+};
+
+export const flattenViewElements = (
+  viewElements: Array<PartialViewElement>,
+  key: string
+) => {
+  return viewElements.reduce<Array<FlattenedPartialViewElement>>(
+    (acc, viewElement) => {
+      if (viewElement[key]) {
+        acc = [
+          ...acc,
+          {
+            ...viewElement,
+            isParent: true
+          }
+        ];
+      } else {
+        acc = [
+          ...acc,
+          {
+            ...viewElement,
+            isParent: false
+          }
+        ];
+      }
+
+      if (isArray(viewElement[key])) {
+        acc = [...acc, ...flattenViewElements(viewElement[key], key)];
+      }
+      return acc;
+    },
+    []
+  );
+};

--- a/packages/demonstrator/navigation/src/components/Navigation.tsx
+++ b/packages/demonstrator/navigation/src/components/Navigation.tsx
@@ -1,0 +1,104 @@
+import { AnimateSharedLayout } from 'framer-motion';
+import React, { FC, useEffect, useMemo } from 'react';
+import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
+
+import { appCompositionState } from '../recoil/features/app/reducers';
+import { partialViewElements, viewNavigationState } from '../recoil/features/view-navigation/reducers';
+import { getComponent, getViewElement } from '../services';
+import { TView, TViewElement } from '../types';
+import { createViewElements, createViews, flattenViewElements } from './Navigation.svc';
+import { View } from './View';
+
+interface NavigationProps {
+  defaultViewElements: Array<TViewElement>;
+}
+
+export const Navigation: FC<NavigationProps> = ({ defaultViewElements }) => {
+  const [{ views, viewElements }, setViewNavigationState] =
+    useRecoilState(viewNavigationState);
+
+  const resetViewNavigationState = useResetRecoilState(viewNavigationState);
+
+  const { isMobile: isMobileManual } = useRecoilValue(appCompositionState);
+
+  useEffect(() => {
+    const flattendViewElements = flattenViewElements(
+      partialViewElements,
+      'siblings'
+    );
+
+    const [initialLeftViews, initialMiddleView, initialRightViews] =
+      createViews(flattendViewElements);
+
+    const initialViewsToConnect = [initialMiddleView, ...initialRightViews];
+
+    const connectedViewElements = createViewElements(
+      flattendViewElements,
+      initialViewsToConnect
+    );
+
+    setViewNavigationState(state => {
+      return {
+        ...state,
+        views: [...initialLeftViews, ...initialViewsToConnect],
+        viewElements: connectedViewElements
+      };
+    });
+    return () => {
+      resetViewNavigationState();
+    };
+  }, []);
+
+  const renderView = (view: TView) => {
+    const renderedViewElements = viewElements
+      .filter(viewElement => viewElement.parentId === view.id)
+      .map(viewElement =>
+        getComponent(
+          getViewElement(defaultViewElements, viewElement.id),
+          viewElement.update
+        )
+      );
+
+    return (
+      <View
+        key={view.id}
+        parentId={view.id} // generated through nanoid
+        position={isMobileManual ? view.position : null}
+        backgroundColor={view.backgroundColor}
+      >
+        {renderedViewElements && renderedViewElements.length > 0
+          ? renderedViewElements
+          : null}
+      </View>
+    );
+  };
+
+  // number of views are equal to number of view elements
+  const viewsToRender = useMemo(() => {
+    const allViewElementParentIds = viewElements.map(
+      viewElement => viewElement.parentId
+    );
+    return views.filter(view => {
+      return allViewElementParentIds.includes(view.id);
+    });
+  }, [views, viewElements]);
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'grid',
+        gridTemplateAreas: isMobileManual && `'left middle right'`,
+        gridTemplateColumns: isMobileManual
+          ? '100% 100% 100%'
+          : `repeat(${viewsToRender.length}, 1fr)`,
+        transform: isMobileManual && 'translateX(-100%)'
+      }}
+    >
+      <AnimateSharedLayout type={'crossfade'}>
+        {isMobileManual ? views.map(renderView) : viewsToRender.map(renderView)}
+      </AnimateSharedLayout>
+    </div>
+  );
+};

--- a/packages/demonstrator/navigation/src/components/TopNavigationControl.tsx
+++ b/packages/demonstrator/navigation/src/components/TopNavigationControl.tsx
@@ -1,0 +1,102 @@
+import { IconButton, Typography } from '@material-ui/core';
+import { ChevronLeft, ChevronRight } from '@material-ui/icons';
+import { CSSProperties } from '@material-ui/styles';
+import React, { FC, useCallback } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { useNavigation } from '../hooks/useNavigation';
+import { appCompositionState } from '../recoil/features/app/reducers';
+import {
+  activeViewIdSelector,
+  hasPreviousOrNextViewSelector,
+  nextViewIdSelector,
+  previousViewIdSelector,
+} from '../recoil/features/view-navigation/reducers';
+
+interface TopNavigationControlProps {
+  style?: CSSProperties;
+}
+
+export const TopNavigationControl: FC<TopNavigationControlProps> = ({
+  style
+}) => {
+  const [hasPrevious, hasNext] = useRecoilValue(hasPreviousOrNextViewSelector);
+
+  const [{ id: activeViewElementId, label: activeViewElementLabel }, ...rest] =
+    useRecoilValue(activeViewIdSelector);
+
+  const { id: previousViewElementId } = useRecoilValue(previousViewIdSelector);
+
+  const { id: nextViewElementId } = useRecoilValue(nextViewIdSelector);
+
+  const navigate = useNavigation();
+
+  const handleBackNavigation = useCallback(
+    (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      navigate(activeViewElementId, previousViewElementId);
+    },
+    [navigate, activeViewElementId, previousViewElementId]
+  );
+
+  const handleForwardNavigation = useCallback(
+    (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      navigate(activeViewElementId, nextViewElementId);
+    },
+    [navigate, activeViewElementId, nextViewElementId]
+  );
+
+  const { isMobile: isMobileManual } = useRecoilValue(appCompositionState);
+
+  const viewLabels = [activeViewElementLabel, ...rest.map(r => r.label)];
+
+  return isMobileManual ? (
+    <div
+      style={{
+        ...style,
+        // width: '100%',
+        height: '48px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
+      }}
+    >
+      {hasPrevious ? (
+        <IconButton onClick={handleBackNavigation}>
+          <ChevronLeft />
+        </IconButton>
+      ) : (
+        <div />
+      )}
+      <Typography variant='h6'>{activeViewElementLabel}</Typography>
+      {hasNext ? (
+        <IconButton onClick={handleForwardNavigation}>
+          <ChevronRight />
+        </IconButton>
+      ) : (
+        <div />
+      )}
+    </div>
+  ) : (
+    <div
+      style={{
+        ...style,
+        // width: '100%',
+        height: '48px',
+        display: 'grid',
+        gridTemplateColumns: `repeat(${viewLabels.length}, 1fr)`
+      }}
+    >
+      {viewLabels.map(viewLabel => (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <Typography variant='h6'>{viewLabel}</Typography>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/demonstrator/navigation/src/components/View.tsx
+++ b/packages/demonstrator/navigation/src/components/View.tsx
@@ -1,0 +1,95 @@
+import { isEmptyString } from '@app/utils/src/string';
+import { motion, MotionProps, SharedLayoutContext, SharedLayoutSyncMethods } from 'framer-motion';
+import React, { FC, ReactNode, useContext, useEffect, useRef } from 'react';
+import ReactReconciler from 'react-reconciler';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import { useParent } from '../hooks/useParent';
+import { reparentReducer, reparentState } from '../recoil/features/reparent/reducers';
+import { TPosition } from '../types';
+import { invariant } from '../utils/invariant';
+import { warning } from '../utils/warning';
+
+type OuterViewProps = {
+  backgroundColor?: string;
+  gridArea: string;
+} & MotionProps;
+
+export const OuterView = styled(motion.div)<OuterViewProps>`
+  grid-area: ${({ gridArea }) => gridArea};
+  width: 100%;
+  height: 100%;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+`;
+
+interface ViewProps {
+  parentId: string;
+  backgroundColor: string;
+  position?: TPosition;
+  // children: ReactElement;
+  children: ReactNode; // not ReactNode,
+}
+
+export const View: FC<ViewProps> = ({
+  parentId,
+  position,
+  backgroundColor,
+  children
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const context = useContext<SharedLayoutSyncMethods>(
+    SharedLayoutContext as any
+  );
+
+  const parent = useParent(ref, (fiber: ReactReconciler.Fiber) => {
+    if (fiber.child != null) {
+      context.syncUpdate();
+    }
+    return fiber;
+  });
+
+  const [reparent, setReparent] = useRecoilState(reparentState);
+
+  const { addItem, removeItem, hasItem } = reparentReducer;
+
+  useEffect(() => {
+    invariant(
+      !isEmptyString(parentId),
+      'You must provide an id to the <View> component.'
+    );
+
+    if (hasItem(reparent, parentId)) {
+      warning(
+        `It seems that a new <View> has been mounted with the id: ${parentId}, while there is another <View> with that id.`
+      );
+    }
+
+    setReparent(state => addItem(state, parentId, parent));
+
+    return () => {
+      setReparent(state => removeItem(state, parentId));
+    };
+  }, []);
+
+  return (
+    <OuterView
+      key={parentId}
+      gridArea={position}
+      backgroundColor={backgroundColor}
+      ref={ref}
+      // For layout props (layout or layoutId) framer-motion calculates transformation of origin.
+      // To overrule or compensate those measures in an outer component we set originX -Y and -Z to 0.
+      layout='position' // not necessary needed
+      layoutId={parentId}
+      // initial={{
+      //   originY: 0,
+      //   originX: 0,
+      //   originZ: 0
+      // }}
+    >
+      {children}
+    </OuterView>
+  );
+};

--- a/packages/demonstrator/navigation/src/components/index.ts
+++ b/packages/demonstrator/navigation/src/components/index.ts
@@ -1,0 +1,4 @@
+export { BottomNavigationControl } from './BottomNavigationControl';
+export { TopNavigationControl } from './TopNavigationControl';
+export { Navigation } from './Navigation';
+export { View } from './View';

--- a/packages/demonstrator/navigation/src/hooks/useNavigation.tsx
+++ b/packages/demonstrator/navigation/src/hooks/useNavigation.tsx
@@ -1,0 +1,68 @@
+import { CollectionUtil } from '@app/utils';
+import { useCallback } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { reparentReducer, reparentState } from '../recoil/features/reparent/reducers';
+import { viewNavigationState } from '../recoil/features/view-navigation/reducers';
+import { navigateById } from '../services/NavigationControl.svc';
+
+export const useNavigation = (): ((
+  activeViewElementId: string,
+  newActiveViewElementId: string
+) => void) => {
+  const reparent = useRecoilValue(reparentState);
+
+  const { sendReparentableChild } = reparentReducer;
+
+  const [{ views, viewElements }, setViewNavigation] =
+    useRecoilState(viewNavigationState);
+
+  const navigate = useCallback(
+    (activeViewElementId: string, newActiveViewElementId: string) => {
+      const { nextViewElements, direction: moveToRight } = navigateById(
+        activeViewElementId,
+        newActiveViewElementId,
+        views,
+        viewElements
+      );
+
+      moveToRight
+        ? nextViewElements.forEach(
+            viewElement =>
+              viewElement.parentId &&
+              viewElement.previousParentId &&
+              sendReparentableChild(
+                reparent,
+                viewElement.previousParentId,
+                viewElement.parentId,
+                0,
+                0
+              )
+          )
+        : CollectionUtil.Array.reverse(nextViewElements).forEach(
+            viewElement =>
+              viewElement.parentId &&
+              viewElement.previousParentId &&
+              sendReparentableChild(
+                reparent,
+                viewElement.previousParentId,
+                viewElement.parentId,
+                0,
+                0
+              )
+          );
+
+      setViewNavigation(state => {
+        return { ...state, viewElements: nextViewElements };
+      });
+    },
+    [
+      views,
+      viewElements,
+      reparent.parentFiberMap,
+      navigateById,
+      setViewNavigation
+    ]
+  );
+  return navigate;
+};

--- a/packages/demonstrator/navigation/src/hooks/useParent.ts
+++ b/packages/demonstrator/navigation/src/hooks/useParent.ts
@@ -1,0 +1,49 @@
+import { MutableRefObject, useEffect, useRef } from 'react';
+import { getFiberFromElementInstance, ParentFiber } from 'react-reparenting';
+
+import { invariant } from '../utils/invariant';
+
+import type { Fiber } from 'react-reconciler';
+/**
+ * An hook to get a ParentFiber instance in a function component.
+ * The ref returned must reference the element that is the parent
+ * of the children to reparent (it is possible to get around this by
+ * providing a findFiber method).
+ *
+ * @param findFiber - Get a different parent fiber.
+ * @returns - The ParentFiber instance.
+ */
+
+export function useParent<T extends Node>(
+  ref: MutableRefObject<T>,
+  findFiber?: (fiber: Fiber) => Fiber
+): MutableRefObject<ParentFiber> {
+  // The reference of the parent fiber instance.
+  const parentRef = useRef<ParentFiber | null>(null);
+
+  // Generate the parent fiber instance.
+  if (parentRef.current === null) {
+    parentRef.current = new ParentFiber();
+  }
+
+  const parent = parentRef.current;
+  parent.setFinder(findFiber);
+
+  // When the component is mounted the fiber is set.
+  useEffect(() => {
+    invariant(
+      ref.current !== null && ref.current !== undefined,
+      'You must set the ref returned by the useParent hook.'
+    );
+
+    // The element fiber.
+    parent.setFiber(getFiberFromElementInstance<T>(ref.current));
+
+    // Clean up.
+    return (): void => {
+      parent.clear();
+    };
+  }, []);
+
+  return parentRef;
+}

--- a/packages/demonstrator/navigation/src/hooks/useScrollRestoration.tsx
+++ b/packages/demonstrator/navigation/src/hooks/useScrollRestoration.tsx
@@ -1,0 +1,36 @@
+import { viewportSelectors } from '@demonstrators-social/shared';
+import { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+export const useScrollRestoration = (
+  currentViewIndex: number,
+  timelineId: string
+) => {
+  const {
+    post: { viewportItemSelector }
+  } = viewportSelectors;
+
+  const { viewportItem } = useRecoilValue(viewportItemSelector(timelineId));
+
+  const setViewportItemState = useSetRecoilState(
+    viewportItemSelector(timelineId)
+  );
+
+  useEffect(() => {
+    if (!viewportItem) return;
+
+    const viewportIntersectingList = Object.values(viewportItem);
+
+    if (currentViewIndex === 2 && viewportIntersectingList.length > 0) {
+      const [observedTopItem] = viewportIntersectingList;
+      setViewportItemState(state => {
+        return {
+          ...state,
+          offsetTop: observedTopItem.offsetTop
+        };
+      });
+    }
+  }, [viewportItem]);
+
+  return null;
+};

--- a/packages/demonstrator/navigation/src/hooks/useScrollRestorationStandalone.tsx
+++ b/packages/demonstrator/navigation/src/hooks/useScrollRestorationStandalone.tsx
@@ -1,0 +1,42 @@
+import { viewportSelectors } from '@demonstrators-social/shared';
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+
+export const useScrollRestoration = (
+  currentViewIndex: number,
+  timelineId: string,
+  _heights: number
+): [MutableRefObject<HTMLDivElement>, number] => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    post: { viewportItemSelector }
+  } = viewportSelectors;
+
+  const { viewportItem } = useRecoilValue(viewportItemSelector(timelineId));
+
+  const [offsetTop, setOffsetTop] = useState(0);
+
+  useEffect(() => {
+    if (!viewportItem) return;
+
+    const viewportIntersectingList = Object.values(viewportItem);
+
+    if (currentViewIndex === 2 && viewportIntersectingList.length > 0) {
+      const [observedTopItem] = viewportIntersectingList;
+      setOffsetTop(_state => observedTopItem.offsetTop);
+    }
+  }, [viewportItem]);
+
+  // do scroll restoration in layout effect, when no annimation is involved
+  // useLayoutEffect(() => {
+  //   if (!containerRef) return;
+
+  //   const scrollArea = containerRef.current;
+
+  //   scrollArea.scroll(0, offsetTop + heights - 8 - scrollArea.offsetTop);
+  //   // scrollArea.scrollTop = offsetTop + heights - scrollArea.offsetTop;
+  // }, [currentViewIndex]);
+
+  return [containerRef, offsetTop];
+};

--- a/packages/demonstrator/navigation/src/index.ts
+++ b/packages/demonstrator/navigation/src/index.ts
@@ -1,0 +1,4 @@
+export * from './components';
+export * from './services';
+export * from './types';
+export * from './recoil/features/view-navigation/reducers';

--- a/packages/demonstrator/navigation/src/recoil/features/app/reducers.ts
+++ b/packages/demonstrator/navigation/src/recoil/features/app/reducers.ts
@@ -1,0 +1,30 @@
+import { EffectRef } from '@huse/effect-ref';
+import { atom } from 'recoil';
+
+export interface AppLayout {
+  appContainer: EffectRef<HTMLElement>;
+  bottomContainer: EffectRef<HTMLElement>;
+}
+
+export const appLayoutInitialState: AppLayout = {
+  appContainer: undefined,
+  bottomContainer: undefined
+};
+
+export const appLayoutState = atom({
+  key: 'app-layout',
+  default: appLayoutInitialState
+});
+
+export interface AppComposition {
+  isMobile: boolean;
+}
+
+export const appCompositionInitialState: AppComposition = {
+  isMobile: true
+};
+
+export const appCompositionState = atom({
+  key: 'app-composition',
+  default: appCompositionInitialState
+});

--- a/packages/demonstrator/navigation/src/recoil/features/reparent/reducers.ts
+++ b/packages/demonstrator/navigation/src/recoil/features/reparent/reducers.ts
@@ -1,0 +1,95 @@
+import get from 'lodash/get';
+import { MutableRefObject } from 'react';
+import { ParentFiber } from 'react-reparenting';
+import { atom } from 'recoil';
+
+import { warning } from '../../../utils/warning';
+
+type ParentFiberMap = { [key: string]: MutableRefObject<ParentFiber> };
+
+export interface ReparentState {
+  parentFiberMap: ParentFiberMap;
+}
+
+export const initialState: ReparentState = {
+  parentFiberMap: {}
+};
+
+// Note:
+// The reparent atom uses the flag dangerouslyAllowMutability, to persist mutable ref-objects.
+// Under ordinary circumstances, recoil allows only read-only values to persist.
+// An option is to use a Jotai atom when recoil deprecates the support for mutability.
+export const reparentState = atom({
+  key: 'reparent',
+  default: initialState,
+  dangerouslyAllowMutability: true
+});
+
+const addItem = (
+  state: ReparentState,
+  id: string,
+  newItem: MutableRefObject<ParentFiber>
+): ReparentState => {
+  return {
+    ...state,
+    parentFiberMap: {
+      ...state.parentFiberMap,
+      [id]: newItem
+    }
+  };
+};
+
+const removeItem = (state: ReparentState, id: string): ReparentState => {
+  const { [id]: deletedItem, ...objectWithoutDeletedProp } =
+    state.parentFiberMap;
+  return {
+    ...state,
+    parentFiberMap: {
+      ...objectWithoutDeletedProp
+    }
+  };
+};
+
+const hasItem = (state: ReparentState, id: string): boolean => {
+  const keys = Object.keys(state.parentFiberMap);
+  if (keys.indexOf(id) === -1) {
+    return false;
+  }
+  return true;
+};
+
+const sendReparentableChild = (
+  state: ReparentState,
+  fromParentId: string,
+  toParentId: string,
+  childSelector: string | number,
+  position: string | number,
+  skipUpdate?: boolean
+): number => {
+  const { parentFiberMap } = state;
+
+  const { current: fromParent } = get(parentFiberMap, fromParentId);
+  const { current: toParent } = get(parentFiberMap, toParentId);
+
+  if (fromParent === undefined) {
+    warning(`Cannot find a <Reparentable> with the id: ${fromParentId}.`);
+  }
+  if (toParent === undefined) {
+    warning(`Cannot find a <Reparentable> with the id: ${toParentId}.`);
+  }
+
+  // Parents ids not valid.
+  if (fromParent === undefined || toParent === undefined) {
+    return -1;
+  }
+
+  // Send the child.
+  return fromParent.sendChild(toParent, childSelector, position, skipUpdate);
+};
+
+export const reparentReducer = {
+  addItem,
+  removeItem,
+  hasItem,
+  sendReparentableChild
+};

--- a/packages/demonstrator/navigation/src/recoil/features/view-navigation/reducers.ts
+++ b/packages/demonstrator/navigation/src/recoil/features/view-navigation/reducers.ts
@@ -1,0 +1,222 @@
+import { CollectionUtil } from '@app/utils';
+import { atom, selector, selectorFamily } from 'recoil';
+
+import { NavigationState, PartialViewElement } from '../../../types';
+import { Position } from '../../../types/View';
+import { appCompositionState } from '../app/reducers';
+
+export const partialViewElements: Array<PartialViewElement> = [
+  {
+    id: 'LeftViewElement',
+    label: 'Author',
+    siblings: []
+  },
+  {
+    id: 'ViewElement',
+    label: 'Actions',
+    siblings: [
+      // {
+      //   id: 'DockViewElementLeft',
+      //   position: Position.left
+      // },
+      // { id: 'DockViewElementRight', position: Position.right }
+    ]
+  },
+  {
+    id: 'RightViewElement',
+    label: 'Consumer',
+    siblings: []
+  }
+];
+
+const initialState: NavigationState = {
+  views: [],
+  viewElements: []
+};
+
+export const viewNavigationState = atom({
+  key: 'view-navigation',
+  default: initialState
+});
+
+// export const activeViewIdSelector = selector<PartialViewElement>({
+//   key: 'active-view-id-selector',
+//   get: ({ get }) => {
+//     const { views, viewElements } = get(viewNavigationState);
+//     const activeView = views.find(view => view.position === Position.middle);
+//     const activeViewElement = viewElements.find(
+//       viewElement => viewElement.parentId === activeView.id
+//     );
+//     return (activeViewElement && activeViewElement) || { id: '', label: '' };
+//   }
+// });
+
+export const activeViewIdSelector = selector<Array<PartialViewElement>>({
+  key: 'active-view-id-selector',
+  get: ({ get }) => {
+    const { views, viewElements } = get(viewNavigationState);
+
+    const { isMobile } = get(appCompositionState);
+
+    if (views.length === 0) return [{ id: '', label: '' }];
+
+    if (isMobile) {
+      const activeView = views.find(view => view.position === Position.middle);
+      const activeViewElement = viewElements.find(
+        viewElement => viewElement.parentId === activeView.id
+      );
+      return [
+        (activeViewElement && activeViewElement) || { id: '', label: '' }
+      ];
+    } else {
+      const allViewIds = views.map(view => view.id);
+      return (
+        viewElements.filter(viewElement => {
+          return allViewIds.includes(viewElement.parentId);
+        }) || [{ id: '', label: '' }]
+      );
+    }
+  }
+});
+
+export const activeViewIndexSelector = selectorFamily<number, string>({
+  key: 'active-view-index-selector',
+  // id corresponds to layoutId
+  get:
+    id =>
+    ({ get }) => {
+      const { views, viewElements } = get(viewNavigationState);
+      const viewElement = viewElements.find(
+        viewElement => viewElement.id === id
+      );
+
+      if (viewElement == null) {
+        return -1;
+      }
+
+      return views.findIndex(
+        view =>
+          view.position === Position.middle && view.id === viewElement.parentId
+      );
+    }
+});
+
+export const previousViewIdSelector = selector<PartialViewElement>({
+  key: 'previous-view-id-selector',
+  get: ({ get }) => {
+    const { views, viewElements } = get(viewNavigationState);
+
+    const allLeftViewIds = views
+      .filter(view => view.position === Position.left)
+      .map(view => view.id);
+
+    const previousViewElement = CollectionUtil.Array.reverse(viewElements).find(
+      viewElement => {
+        const include = allLeftViewIds.includes(viewElement.parentId);
+        return include;
+      }
+    );
+
+    return (previousViewElement && previousViewElement) || { id: '' };
+  }
+});
+
+export const nextViewIdSelector = selector<PartialViewElement>({
+  key: 'next-view-id-selector',
+  get: ({ get }) => {
+    const { views, viewElements } = get(viewNavigationState);
+
+    const allRightViewIds = views
+      .filter(view => view.position === Position.right)
+      .map(view => view.id);
+
+    const nextViewElement = viewElements.find(viewElement => {
+      const include = allRightViewIds.includes(viewElement.parentId);
+      return include;
+    });
+
+    return (nextViewElement && nextViewElement) || { id: '' };
+  }
+});
+
+export const hasPreviousOrNextViewSelector = selector<[boolean, boolean]>({
+  key: 'has-previous-or-next-view-selector',
+  get: ({ get }) => {
+    const { views, viewElements } = get(viewNavigationState);
+
+    const allViewElementParentIds = viewElements.map(
+      viewElement => viewElement.parentId
+    );
+
+    const allLeftViewIds = views
+      .filter(view => view.position === Position.left)
+      .map(view => view.id);
+
+    const allRightViewIds = views
+      .filter(view => view.position === Position.right)
+      .map(view => view.id);
+
+    const hasPrevious = CollectionUtil.Array.findCommonIds(
+      allViewElementParentIds,
+      allLeftViewIds
+    );
+    const hasNext = CollectionUtil.Array.findCommonIds(
+      allViewElementParentIds,
+      allRightViewIds
+    );
+
+    return [hasPrevious, hasNext];
+  }
+});
+
+// Separate views
+
+// Simple move steps | left to right
+
+// A = left, B = middle, C = right
+
+// A [ F ] | B [ G    ] | C [   ]
+
+// A [   ] > B [ F, G ] | C [   ]
+
+// A [   ] | B [ F    ] > C [ G ]
+
+// Source views => Target views
+// A [ F ] | B [ G ] => B [ F ] | C [ G ]
+
+// Simple move steps | left to right
+
+// A [ F ] | B [   ] | C [ G    ] | D [   ]
+
+// A [   ] > B [ F ] | C [ G    ] | D [   ]
+
+// A [   ] | B [   ] > C [ F, G ] | D [   ]
+
+// A [   ] | B [   ] | C [ F    ] > D [ G ]
+
+// Source views => Target views
+// A [ F ] | C [ G ] => C [ F ] | D [ G ]
+
+// Normalise
+
+// A [ F ] | B [ G ]
+
+// A [   ] > B [ F, G ]
+
+// A [   ] | B [ F    ] > C [ G ]
+
+// Source views => Target views
+
+// A [ F ] | B [ G ] => B [ F ] > C [ G ]
+
+// Normalise middle right to left
+
+// B [ F ] | C [ G ]
+
+// B [ F, G ] < C [ ]
+
+// A [ F ] < B [ G ]  | C [ ]
+
+// Source views => Target views
+
+// B [ F ] | C [ G ] => A [ F ] > B [ G ]

--- a/packages/demonstrator/navigation/src/services/Navigation.svc.tsx
+++ b/packages/demonstrator/navigation/src/services/Navigation.svc.tsx
@@ -1,0 +1,25 @@
+import { TViewElement } from '../types';
+
+export const getViewElement = (
+  viewElements: Array<TViewElement>,
+  viewElementId: string
+) => {
+  return viewElements.find(viewElement => viewElement.id === viewElementId);
+};
+
+export const getComponent = (
+  viewElement: TViewElement,
+  _update: boolean = true
+) => {
+  const { key, id, component: Component } = viewElement;
+
+  return Component ? (
+    <Component
+      key={key}
+      layoutId={id}
+      layout={'position'}
+      // layoutId={update ? id : undefined}
+      // layout={update ? 'position' : false}
+    />
+  ) : null;
+};

--- a/packages/demonstrator/navigation/src/services/NavigationControl.svc.ts
+++ b/packages/demonstrator/navigation/src/services/NavigationControl.svc.ts
@@ -1,0 +1,62 @@
+import { PartialViewElement, TView } from '../types';
+
+export const navigateById = (
+  fromViewElementId: string,
+  toViewElementId: string,
+  views: Array<TView>,
+  viewElements: Array<PartialViewElement>
+) => {
+  // find the view element, currently centered
+  // has to move from its current location (center) to a left or right placeholder
+  const fromViewElement = viewElements.find(
+    viewElement => viewElement.id === fromViewElementId
+  );
+
+  // find the the view elements parent position in all views
+  const fromViewIndex = views.findIndex(
+    view => view.id === fromViewElement.parentId
+  );
+
+  // find the next view element, which has to be centered
+  const toViewElement = viewElements.find(
+    viewElement => viewElement.id === toViewElementId
+  );
+
+  // find the the view elements parent position in all views
+  const toViewIndex = views.findIndex(
+    view => view.id === toViewElement.parentId
+  );
+
+  const distance = toViewIndex - fromViewIndex;
+
+  // does not use distance (Vorzeichen) to indicate direction
+  const moveToRight = toViewIndex > fromViewIndex;
+
+  // currentViewElements and nextViewElements have to be identical in size
+  const nextViewElements = viewElements.reduce<Array<PartialViewElement>>(
+    (acc, viewElement) => {
+      const fromView = views.find(view => view.id === viewElement.parentId);
+
+      const fromViewIndex = views.findIndex(
+        view => view.id === viewElement.parentId
+      );
+
+      const toView = views[fromViewIndex - distance];
+
+      return [
+        ...acc,
+        {
+          ...viewElement,
+          parentId: toView.id,
+          previousParentId: fromView.id
+        }
+      ];
+    },
+    []
+  );
+
+  return {
+    nextViewElements,
+    direction: moveToRight
+  };
+};

--- a/packages/demonstrator/navigation/src/services/index.ts
+++ b/packages/demonstrator/navigation/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './Navigation.svc';
+export * from './NavigationControl.svc';

--- a/packages/demonstrator/navigation/src/types/Navigation.ts
+++ b/packages/demonstrator/navigation/src/types/Navigation.ts
@@ -1,0 +1,7 @@
+import { TView } from './View';
+import { PartialViewElement } from './ViewElement';
+
+export interface NavigationState {
+  views: Array<TView>;
+  viewElements: Array<PartialViewElement>;
+}

--- a/packages/demonstrator/navigation/src/types/View.ts
+++ b/packages/demonstrator/navigation/src/types/View.ts
@@ -1,0 +1,13 @@
+export const Position = {
+  left: 'left',
+  middle: 'middle',
+  right: 'right'
+} as const;
+
+export type TPosition = typeof Position[keyof typeof Position];
+
+export interface TView {
+  id: string; // parentId
+  position: TPosition;
+  backgroundColor?: string;
+}

--- a/packages/demonstrator/navigation/src/types/ViewElement.ts
+++ b/packages/demonstrator/navigation/src/types/ViewElement.ts
@@ -1,0 +1,31 @@
+import { MotionProps } from 'framer-motion';
+import { ComponentType } from 'react';
+
+import { TPosition } from './View';
+
+export interface PartialViewElement {
+  id: string; // layoutId,
+  parentId?: string; // programmatical determination before before initial state,
+  label?: string;
+  previousParentId?: string;
+  update?: boolean;
+  siblingOf?: string;
+  siblings?: Array<PartialViewElement>;
+  constellation?: Array<string>;
+  position?: TPosition;
+}
+
+export type FlattenedPartialViewElement = Omit<
+  PartialViewElement,
+  'constellation'
+> & {
+  isParent?: boolean;
+};
+
+export interface ViewElementProps extends MotionProps {}
+
+export interface TViewElement extends PartialViewElement {
+  key: string;
+  backgroundColor?: string;
+  component: ComponentType<ViewElementProps>;
+}

--- a/packages/demonstrator/navigation/src/types/index.ts
+++ b/packages/demonstrator/navigation/src/types/index.ts
@@ -1,0 +1,8 @@
+export type { NavigationState } from './Navigation';
+export type { TPosition, TView } from './View';
+export type {
+  PartialViewElement,
+  TViewElement,
+  ViewElementProps,
+  FlattenedPartialViewElement
+} from './ViewElement';

--- a/packages/demonstrator/navigation/src/utils/invariant.ts
+++ b/packages/demonstrator/navigation/src/utils/invariant.ts
@@ -1,0 +1,30 @@
+const prefix = 'Invariant failed';
+
+// Invariant error instance.
+export class Invariant extends Error {
+  name = 'Invariant';
+}
+
+/**
+ * Throw an error if the condition fails.
+ * The message is tripped in production.
+ *
+ * @param condition - The condition.
+ * @param message   - The error message.
+ */
+export function invariant(
+  condition: boolean,
+  _message?: string
+): asserts condition {
+  if (condition) return;
+
+  // if (__DEV__) {
+  //   // When not in production we allow the message to pass through.
+  //   throw new Invariant(`${prefix}: ${message || ''}`);
+  // } else {
+  //   // In production we strip the message but still throw.
+  //   throw new Invariant(prefix);
+  // }
+
+  throw new Invariant(prefix);
+}

--- a/packages/demonstrator/navigation/src/utils/warning.ts
+++ b/packages/demonstrator/navigation/src/utils/warning.ts
@@ -1,0 +1,23 @@
+/**
+ * Prints a warning in the console.
+ *
+ * @param message - The warning message.
+ */
+export function warning(message: string): void {
+  const text = `Warning: ${message}`;
+
+  // Check console for IE9 support which provides console
+  // only with open devtools.
+  if (typeof console !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.error(text);
+  }
+
+  // Throwing an error and catching it immediately
+  // to improve debugging.
+  // A consumer can use 'pause on caught exceptions'
+  // https://github.com/facebook/react/issues/4216
+  try {
+    throw Error(text);
+  } catch (x) {} // eslint-disable-line no-empty
+}

--- a/packages/demonstrator/navigation/tsconfig.json
+++ b/packages/demonstrator/navigation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "preserve",
+    "skipLibCheck": true
+  },
+  "include": ["**/*.d.ts", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/utils/src/collection/array.ts
+++ b/packages/utils/src/collection/array.ts
@@ -118,3 +118,15 @@ export const takeNRandom = <T>(arr: Array<T>, num: number) => {
 export const compareDescFn = (field: string) => (a: any, b: any) => {
   return compareDesc(get(a, field), get(b, field));
 };
+
+export const reverse = <T>(array: Array<T>) => {
+  // Spread, reverse
+  return [...array].reverse();
+
+  // alternative
+  // return array.slice().reverse();
+};
+
+export const findCommonIds = (a: Array<string>, b: Array<string>) => {
+  return a.some(item => b.includes(item));
+};


### PR DESCRIPTION
The navigation component splits or cuts a wide UI view into multiple, narrower views. The user observes only a portion of the overall user interface of an application at any given time.

The primary use case is the creation of views whose elements have a visual, or geometric overlap with elements of neighbouring views. This dependency imposes requirements that differ significantly from other navigation-oriented rendering modules such as React Navigation.

Key requirements include
1. fluid and uninterrupted entry and exit of views into the viewing area (this is described in more detail below)
2. flexible controls for composing views and navigating between them.

The display elements included in a view vary in complexity and workload. The effort to achieve coordination of display elements that are included in adjacent views is considered to be rather heavy.

Therefore, the requirements specification presupposes a procedure that is not provided by React in this form.

The behaviour known as re-parenting allows to assign a component to other parents without forcing a shutdown followed by a restart of the component (re-mounting). This phenomenon is caused by a conditional rendering of components or their assignment to the respective parent.