### PR TITLE
Fix content shift in demonstrator

### DIFF
--- a/packages/demonstrator/navigation/src/components/TopNavigationControl.tsx
+++ b/packages/demonstrator/navigation/src/components/TopNavigationControl.tsx
@@ -53,7 +53,6 @@ export const TopNavigationControl: FC<TopNavigationControlProps> = ({
     <div
       style={{
         ...style,
-        // width: '100%',
         height: '48px',
         display: 'flex',
         alignItems: 'center',
@@ -80,15 +79,15 @@ export const TopNavigationControl: FC<TopNavigationControlProps> = ({
     <div
       style={{
         ...style,
-        // width: '100%',
-        height: '48px',
         display: 'grid',
         gridTemplateColumns: `repeat(${viewLabels.length}, 1fr)`
       }}
     >
       {viewLabels.map(viewLabel => (
         <div
+          key={viewLabel}
           style={{
+            height: '48px',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center'


### PR DESCRIPTION
The top navigation control uses two layout variants, one for desktop, the other for mobile. In the desktop variant, the height in the surrounding grid-based container gets not respected; move the height declaration to the elements within.