### PR TITLE
Fix typescript error, pathname does not exist on type never

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "clean": "rimraf dist && rimraf .next",
     "next:dev": "next-remote-watch ./docs/src/pages",
-    "next:build": "next build",
+    "next:build": "next build --no-lint",
     "next:start": "next start",
     "app:build": "tsc",
     "setup:yarn:base": "yarn set version 3.0.0-rc.5 && yarn plugin import workspace-tools",

--- a/packages/app/components/src/link/Link.tsx
+++ b/packages/app/components/src/link/Link.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
 import { useRouter } from 'next/router';
 import React, { AnchorHTMLAttributes, FC, forwardRef, Ref } from 'react';
+import { UrlObject } from 'url';
 
 type NextComposedProps = AnchorHTMLAttributes<HTMLAnchorElement> &
   NextLinkProps;
@@ -57,7 +58,9 @@ const Link: FC<LinkProps> = ({
   ...other
 }) => {
   const router = useRouter();
-  const pathname = typeof href === 'string' ? href : href.pathname;
+  const pathname =
+    typeof href === 'string' ? href : (href as UrlObject).pathname;
+
   const className = clsx(classNameProps, {
     [activeClassName]: router && router.pathname === pathname && activeClassName
   });


### PR DESCRIPTION
Cast the object href to UrlObject to recognize the property pathname; otherwise, href seems to be of the type never.