### PR TITLE
Fix selecting actions in the speed-dial component

### DIFF
--- a/packages/demonstrators/social/flow/src/components/options/SliceOptions.tsx
+++ b/packages/demonstrators/social/flow/src/components/options/SliceOptions.tsx
@@ -72,9 +72,6 @@ const createButton = ({ title, icon, action }) => (
     tooltipTitle={title}
     onClick={action}
     tooltipPlacement={'left'}
-    sx={{
-      pointerEvents: 'auto'
-    }}
   />
 );
 
@@ -123,7 +120,8 @@ export const SliceOptions: FC = () => {
       style={{
         width: theme.spacing(APP_CONTENT_SHARE_DIMENSION),
         height: theme.spacing(APP_CONTENT_SHARE_DIMENSION),
-        margin: theme.spacing(0, 2)
+        margin: theme.spacing(0, 2),
+        zIndex: 1050
       }}
     >
       <SpeedDial

--- a/packages/page/components/src/share/Share.tsx
+++ b/packages/page/components/src/share/Share.tsx
@@ -161,9 +161,6 @@ const creataShareLink = ({ title, icon, action }) => (
     tooltipTitle={title}
     onClick={action}
     tooltipPlacement={'left'}
-    sx={{
-      pointerEvents: 'auto'
-    }}
   />
 );
 
@@ -236,7 +233,8 @@ export const Share: FC<PageTypes.ContentMetaData> = props => {
       style={{
         width: theme.spacing(APP_CONTENT_SHARE_DIMENSION),
         height: theme.spacing(APP_CONTENT_SHARE_DIMENSION),
-        margin: theme.spacing(0, 2)
+        margin: theme.spacing(0, 2),
+        zIndex: 1050
       }}
     >
       <SpeedDial


### PR DESCRIPTION
Revert previous change - remove pointer-events entirely. Instead, apply the identical z-index value (1050) used within the speed-dial component to the wrapper.