### PR TITLE
Remove snapping of drawer animation

### DIFF
--- a/packages/app/layout/src/components/drawer/MobileDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/MobileDrawer.tsx
@@ -5,19 +5,17 @@ import React, { FC } from 'react';
 
 import { DrawerProps } from '.';
 
-const SwipeableDrawer = styled(MuiSwipeableDrawer)(({ theme, open }) => ({
-  ...(open && {
-    '& .MuiDrawer-paper': {
-      width: theme.spacing(MAX_DRAWER_WIDTH),
-      // Important:
-      // Correct the layout shift among supported drawers switching
-      // from the mobile to the desktop variant and vice versa.
-      borderRight: `1px solid #000000`
-      // The palette divider theme corresponds to the border-right
-      // style applied in the desktop drawer variant
-      // borderRight: `1px solid ${theme.palette.divider}`,
-    }
-  })
+const SwipeableDrawer = styled(MuiSwipeableDrawer)(({ theme }) => ({
+  '& .MuiDrawer-paper': {
+    width: theme.spacing(MAX_DRAWER_WIDTH),
+    // Important:
+    // Correct the layout shift among supported drawers switching
+    // from the mobile to the desktop variant and vice versa.
+    borderRight: `1px solid #000000`
+    // The palette divider theme corresponds to the border-right
+    // style applied in the desktop drawer variant
+    // borderRight: `1px solid ${theme.palette.divider}`,
+  }
 }));
 
 export const MobileDrawer: FC<DrawerProps> = ({

--- a/packages/app/layout/src/components/drawer/SwitchDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/SwitchDrawer.tsx
@@ -62,11 +62,9 @@ export const SwitchDrawer: FC<DrawerProps> = ({
         </IconButton>
       </Link>
 
-      {isDrawerExpanded && (
-        <IconButton onClick={handleDrawerClose}>
-          <ChevronLeft />
-        </IconButton>
-      )}
+      <IconButton onClick={handleDrawerClose}>
+        <ChevronLeft />
+      </IconButton>
     </DrawerHeader>
   );
 
@@ -79,7 +77,7 @@ export const SwitchDrawer: FC<DrawerProps> = ({
           handleDrawerClose={handleDrawerClose}
         >
           {headerComp}
-          <Divider variant='middle' flexItem />
+          <Divider variant='middle' />
           {treeComp}
         </MobileDrawer>
       </Media>
@@ -90,7 +88,7 @@ export const SwitchDrawer: FC<DrawerProps> = ({
           handleDrawerClose={handleDrawerClose}
         >
           {headerComp}
-          <Divider variant='middle' flexItem />
+          <Divider variant='middle' />
           {treeComp}
         </DesktopDrawer>
       </Media>


### PR DESCRIPTION
The mobile drawer width has to be permanently set to MAX_DRAWER_WIDTH; doing it only in the open state causes a fallback to width=100%, which is different from a specific with provided, resulting in a flickering when transitions from and to the state "open" occur. Remove conditional render for drawer closing.