### PR TITLE
Resolve conflicting dependencies of ahooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,9 @@
   "resolutions": {
     "next": "11.1.3-canary.24",
     "@types/unist": "2.0.4",
-    "mdast-util-toc": "5.1.0"
+    "mdast-util-toc": "5.1.0",
+    "ahooks": "2.10.9",
+    "@ahooksjs/use-request": "2.8.10"
   },
   "engines": {
     "node": "12.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 4
   cacheKey: 8
 
-"@ahooksjs/use-request@npm:^2.8.10":
+"@ahooksjs/use-request@npm:2.8.10":
   version: 2.8.10
   resolution: "@ahooksjs/use-request@npm:2.8.10"
   dependencies:
@@ -279,11 +279,11 @@ __metadata:
   linkType: soft
 
 "@artsy/fresnel@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@artsy/fresnel@npm:3.0.1"
+  version: 3.0.2
+  resolution: "@artsy/fresnel@npm:3.0.2"
   peerDependencies:
     react: ">=16.3.0 <18.0.0"
-  checksum: 4c611db11c108f863c348151e0c3493b13178c52e6c76131d756b85ed000b50386186020513ddec05524319b9d3b0d556e447ab37d9db04620819b081bc5e837
+  checksum: 1287d0ce95a0c92317cb79ac3829a73cc30f8d389d1fd972cd1a45fdb121dd83450ba9c5e336b54b102fb12563ad18aa81ff8bdb72fb8b85466052ac27ad8d88
   languageName: node
   linkType: hard
 
@@ -2273,14 +2273,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/core@npm:27.2.0"
+"@jest/core@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "@jest/core@npm:27.2.1"
   dependencies:
     "@jest/console": ^27.2.0
-    "@jest/reporters": ^27.2.0
+    "@jest/reporters": ^27.2.1
     "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     "@types/node": "*"
     ansi-escapes: ^4.2.1
@@ -2289,15 +2289,15 @@ __metadata:
     exit: ^0.1.2
     graceful-fs: ^4.2.4
     jest-changed-files: ^27.1.1
-    jest-config: ^27.2.0
+    jest-config: ^27.2.1
     jest-haste-map: ^27.2.0
     jest-message-util: ^27.2.0
     jest-regex-util: ^27.0.6
     jest-resolve: ^27.2.0
-    jest-resolve-dependencies: ^27.2.0
-    jest-runner: ^27.2.0
-    jest-runtime: ^27.2.0
-    jest-snapshot: ^27.2.0
+    jest-resolve-dependencies: ^27.2.1
+    jest-runner: ^27.2.1
+    jest-runtime: ^27.2.1
+    jest-snapshot: ^27.2.1
     jest-util: ^27.2.0
     jest-validate: ^27.2.0
     jest-watcher: ^27.2.0
@@ -2311,7 +2311,7 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 3f6622f6c9b01a270598ad5740d62e863a19cf7be2e491ccfcd70e757dab721105348e9e7cc09e2beaac13450fee6f0e226754ac682f33b30de0a6ac69d44d71
+  checksum: 230ae7e1b9804f0e46220f2115cefa583573ef279955c4301ee1c2839d77355ecfae37f850ece146b03058827b08f1a84f7838735d3b4791f72c743d26b73cb1
   languageName: node
   linkType: hard
 
@@ -2341,25 +2341,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/globals@npm:27.2.0"
+"@jest/globals@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "@jest/globals@npm:27.2.1"
   dependencies:
     "@jest/environment": ^27.2.0
     "@jest/types": ^27.1.1
-    expect: ^27.2.0
-  checksum: ec1f29fc25835b2347cbaad13145654fe25d34506af341175a06f3a4c16bb6c7d7a19ab8a4759e52f81562f939125469bacc7fce3f8658dd1e60a0e77bdaedfa
+    expect: ^27.2.1
+  checksum: 1f04b6f98b26338cdac4cf249bcd58a3808749e56bb8c47ae61b6d552cff2456da5ff545b1a00e4e683850d917d45b9551874c74d5027b38701568cddd02ca30
   languageName: node
   linkType: hard
 
-"@jest/reporters@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/reporters@npm:27.2.0"
+"@jest/reporters@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "@jest/reporters@npm:27.2.1"
   dependencies:
     "@bcoe/v8-coverage": ^0.2.3
     "@jest/console": ^27.2.0
     "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     chalk: ^4.0.0
     collect-v8-coverage: ^1.0.0
@@ -2385,7 +2385,7 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: afb433b8f0afc038b3fb70bbb464926d80110e28d9a301c56a4d27fc46ccc7a0cf7369a4247b9e097c5eba396c69facb1c9f1c1870d40eb05cc970086423b85c
+  checksum: 24290ca7cedfc0258a77c764f31e699d0e8343c994c758a2b68141938ab13bb598af2a2e9816a84dfac87d943dd8a6eb77bb5af9e3d739f7112600feab2a5e39
   languageName: node
   linkType: hard
 
@@ -2412,21 +2412,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/test-sequencer@npm:27.2.0"
+"@jest/test-sequencer@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "@jest/test-sequencer@npm:27.2.1"
   dependencies:
     "@jest/test-result": ^27.2.0
     graceful-fs: ^4.2.4
     jest-haste-map: ^27.2.0
-    jest-runtime: ^27.2.0
-  checksum: 8df5166f44d512de5b09ba004d3cf3e1f0d8f631a64b304afdcf3441363656541d3f7663eea401e5247ec4e64dd92e7e96172c1455c6fceec4b7ed4bb4b4a333
+    jest-runtime: ^27.2.1
+  checksum: 4d5a096ae9b9eebe056796274fd6c4d929e1c5e2b6ed7fa55604785c03041f40067791b655052e6df35073157ef3bbe2911f1683adf6d081ac6e819c467d9988
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/transform@npm:27.2.0"
+"@jest/transform@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "@jest/transform@npm:27.2.1"
   dependencies:
     "@babel/core": ^7.1.0
     "@jest/types": ^27.1.1
@@ -2443,7 +2443,7 @@ __metadata:
     slash: ^3.0.0
     source-map: ^0.6.1
     write-file-atomic: ^3.0.0
-  checksum: 0bd4ad3ce2b12765d0c015001e2eb9b864ac20eda2805a4da4a3be5cf1dc3f6be51a018ce6d6c782d0afdd7708a63db16ff7b1294315eae8b716aea1188ea00c
+  checksum: c27d7a178c3654ecb93a95975975cd9a835129ea948f1a734501cbf147c9b2572b1a554dc4ce492cb16e7ed9460e83e47989ef5d0b86f8e9489d97f0f127ddac
   languageName: node
   linkType: hard
 
@@ -3344,12 +3344,12 @@ __metadata:
   linkType: hard
 
 "@types/jest@npm:^27.0.1":
-  version: 27.0.1
-  resolution: "@types/jest@npm:27.0.1"
+  version: 27.0.2
+  resolution: "@types/jest@npm:27.0.2"
   dependencies:
     jest-diff: ^27.0.0
     pretty-format: ^27.0.0
-  checksum: 972aaae341b83eb608970c93295282f1f9edc056dc8123635456cbaced822702673118d60279c7b889300e7c9a0726c3674d701115915e2e1967db09542389c2
+  checksum: 814ad5f5d2f277849f47e52906da4b745758e555630fc8cb46a071bde648eefeffb1b35710c530a8cea7fc4ea7c1d813812c120484bf7902ab6c5e473cdd49c9
   languageName: node
   linkType: hard
 
@@ -3607,11 +3607,11 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.31.1"
+  version: 4.31.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.31.2"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.31.1
-    "@typescript-eslint/scope-manager": 4.31.1
+    "@typescript-eslint/experimental-utils": 4.31.2
+    "@typescript-eslint/scope-manager": 4.31.2
     debug: ^4.3.1
     functional-red-black-tree: ^1.0.1
     regexpp: ^3.1.0
@@ -3623,66 +3623,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 90bed374dcdb5497a829f6bb02aa2a88dfb74683b0385b433e29a34b03d4b0f2992cd953cee20426c35c2695fb75845824860a77aca12481e9a1f823c4158bf8
+  checksum: 5d0c2ff34d5a263d2c7e5455ae5844cd24f34eac013e7a1189a959d4edb3ce2312cf340bc78f9a346e64cc3a73e1c8bd9ed367a58ba8633acd04122ad7304b82
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/experimental-utils@npm:4.31.1"
+"@typescript-eslint/experimental-utils@npm:4.31.2":
+  version: 4.31.2
+  resolution: "@typescript-eslint/experimental-utils@npm:4.31.2"
   dependencies:
     "@types/json-schema": ^7.0.7
-    "@typescript-eslint/scope-manager": 4.31.1
-    "@typescript-eslint/types": 4.31.1
-    "@typescript-eslint/typescript-estree": 4.31.1
+    "@typescript-eslint/scope-manager": 4.31.2
+    "@typescript-eslint/types": 4.31.2
+    "@typescript-eslint/typescript-estree": 4.31.2
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 0767a1a554b78e3a81df28a40d213b0ca8d16e2360e04a377d99fceec4cf6af132953076fe6ed5a07708e6115091d18744a6b4904878e029bb22278e84193f59
+  checksum: 0c251effbab00ee26eaaa78540b2988ff24550564e6dea9e31190c1d120e846afb3882394be4d65fac53008f6feb5abc66723826ed093d09c49c14374630b8fb
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/parser@npm:4.31.1"
+  version: 4.31.2
+  resolution: "@typescript-eslint/parser@npm:4.31.2"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.31.1
-    "@typescript-eslint/types": 4.31.1
-    "@typescript-eslint/typescript-estree": 4.31.1
+    "@typescript-eslint/scope-manager": 4.31.2
+    "@typescript-eslint/types": 4.31.2
+    "@typescript-eslint/typescript-estree": 4.31.2
     debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: e4e312ec1ef1666fe3ed9cd565f85cc5e11d0a5ae4dff529fc8f212cc758f46ec8ebd388194a57f73ea3250e0ec9040fef8bee32d922d88153c04870683773fa
+  checksum: e0f83958483326942241838f672291a652ce30078c1a9faac0a99ff381c977c1e568bf0591593e3f5bd4e492fb7d91dbabde965ef5e3296e6f28de127db3107b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/scope-manager@npm:4.31.1"
+"@typescript-eslint/scope-manager@npm:4.31.2":
+  version: 4.31.2
+  resolution: "@typescript-eslint/scope-manager@npm:4.31.2"
   dependencies:
-    "@typescript-eslint/types": 4.31.1
-    "@typescript-eslint/visitor-keys": 4.31.1
-  checksum: 386442e7713df96cf32565e0f3caff173a9206630f385c1cfa09f11d8b4479a9f51572a4b795e4b68b2740bacebd1bb3a3de5a69bee564bc28dbce4b035ed3fb
+    "@typescript-eslint/types": 4.31.2
+    "@typescript-eslint/visitor-keys": 4.31.2
+  checksum: 5560dcbe0fbb629967071f88ab4767cb7e443f2a2008724e1dc0d974bf16cf89400180d3bf56206bf3e7d6c49ad3b22c72b8c465c826510979b4513dad3e6b2d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/types@npm:4.31.1"
-  checksum: 08b5cf0d02fbf946a4b10e93279e3253287e4826ee744e7d3f38d7da241aaa6fce2743e448f9cdf36d93c20259e17248e50b9fffdff59e1c878289acca0c2d65
+"@typescript-eslint/types@npm:4.31.2":
+  version: 4.31.2
+  resolution: "@typescript-eslint/types@npm:4.31.2"
+  checksum: 361533ef9d921ead2e4aac9f097dd01468e84eca2d73157ec02c13fa164688fa1d58497a1a4519f00a5eb88d67efdea279ebc365328aa7371a0466b6ff8149bc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/typescript-estree@npm:4.31.1"
+"@typescript-eslint/typescript-estree@npm:4.31.2":
+  version: 4.31.2
+  resolution: "@typescript-eslint/typescript-estree@npm:4.31.2"
   dependencies:
-    "@typescript-eslint/types": 4.31.1
-    "@typescript-eslint/visitor-keys": 4.31.1
+    "@typescript-eslint/types": 4.31.2
+    "@typescript-eslint/visitor-keys": 4.31.2
     debug: ^4.3.1
     globby: ^11.0.3
     is-glob: ^4.0.1
@@ -3691,17 +3691,17 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 1780223f52fde98fcfef4e7d9a59fc811232f608800e6a69b73789aad34ddf43fc9d4041707baa88b25cf88c223a7f2a749cf084dc45d89de44a803b29e19eb3
+  checksum: 75df8e5341f581d3303b237b9b32bef3e63e87114d14ed5896c293f25ec253e6ef8489752cf78ca0fbfc3cf1d4deb122a22b92b57bfb845bc0fa41812a04e34c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.31.1":
-  version: 4.31.1
-  resolution: "@typescript-eslint/visitor-keys@npm:4.31.1"
+"@typescript-eslint/visitor-keys@npm:4.31.2":
+  version: 4.31.2
+  resolution: "@typescript-eslint/visitor-keys@npm:4.31.2"
   dependencies:
-    "@typescript-eslint/types": 4.31.1
+    "@typescript-eslint/types": 4.31.2
     eslint-visitor-keys: ^2.0.0
-  checksum: 14a86bf96a41a81feba32f5acbb72539345a33f250b2f17968dc7b9f4ae9eca00209a11dd208b9c6305f5a841a9f809713027c0ed969465e2d62a042d116bdc9
+  checksum: 5f3d16d3d282e9b4b02acd06e787e182e9afb9e0a1c42a19268d9f8e02895163ff81674281db27e4777cc239675d6be2abfab8129458f670fe0c17a0d19ad796
   languageName: node
   linkType: hard
 
@@ -3993,7 +3993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ahooks@npm:^2.10.9":
+"ahooks@npm:2.10.9":
   version: 2.10.9
   resolution: "ahooks@npm:2.10.9"
   dependencies:
@@ -4338,11 +4338,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "babel-jest@npm:27.2.0"
+"babel-jest@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "babel-jest@npm:27.2.1"
   dependencies:
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     "@types/babel__core": ^7.1.14
     babel-plugin-istanbul: ^6.0.0
@@ -4352,7 +4352,7 @@ __metadata:
     slash: ^3.0.0
   peerDependencies:
     "@babel/core": ^7.8.0
-  checksum: 82de77285be55e25b7dc01af852ad11c6eb48588392d03448ab8533cd4edcb6972baf6f9ddfb56dbdbe8bc30494e51e994598de1be8954af9fb98f76c9b4ac88
+  checksum: a28d7135e64462edb6b825c033025828ec6482926b5d6bdb0902128e8635dfe5a8871facab69c26b802d86ca50b9af4b2ea4415fde572a8b32583f78d9bfe55a
   languageName: node
   linkType: hard
 
@@ -4930,9 +4930,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001202, caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001228, caniuse-lite@npm:^1.0.30001254":
-  version: 1.0.30001258
-  resolution: "caniuse-lite@npm:1.0.30001258"
-  checksum: 2e87875a7792444f18060f836dbe1a3fcf58dcdd4608c63725dac503aadd617c2bb771c766963fb31528c10fd55201a7cf3ece555a3e754f94ee4a991626c302
+  version: 1.0.30001259
+  resolution: "caniuse-lite@npm:1.0.30001259"
+  checksum: 4b0423693616a62d3a9beaa35ab5a414a9e4398df7361915ca2b6f24142f1f55909e014d5f0c14c034c0fd5084524116ab46bcdfae5c3b8620f11f2822a1c4ba
   languageName: node
   linkType: hard
 
@@ -6151,9 +6151,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.3.723, electron-to-chromium@npm:^1.3.830":
-  version: 1.3.843
-  resolution: "electron-to-chromium@npm:1.3.843"
-  checksum: 4adb18cf1c0f3ee8014fe6976c3e9a2c5f05353a9fd9712cf95a578ede66cd3d85106a764b6d0291c81ca31edcd8f5da4a2f7606858a11e31e410c1e6ea3f303
+  version: 1.3.845
+  resolution: "electron-to-chromium@npm:1.3.845"
+  checksum: 2e14aa373173686b34e34a7dd9793a4fe19441a0e0586c20c0500ac1a646bb6673408d55f92cf48235891a80bf26456efd709a2a38561dfc5887f9e255108a57
   languageName: node
   linkType: hard
 
@@ -6505,8 +6505,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react@npm:^7.25.3":
-  version: 7.25.3
-  resolution: "eslint-plugin-react@npm:7.25.3"
+  version: 7.26.0
+  resolution: "eslint-plugin-react@npm:7.26.0"
   dependencies:
     array-includes: ^3.1.3
     array.prototype.flatmap: ^1.2.4
@@ -6520,10 +6520,11 @@ __metadata:
     object.values: ^1.1.4
     prop-types: ^15.7.2
     resolve: ^2.0.0-next.3
+    semver: ^6.3.0
     string.prototype.matchall: ^4.0.5
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7
-  checksum: a451527938aa02e530d37e7a014f9a19069acc344f95ff079128c71e7faa93715cbd4be6d6aba2c755abe1b7dc20db061759b73a46750a8540cd14558c089419
+  checksum: 363c2ed43ae0c6457c6ad1e7e7c561892189d3e1253a7d5e369413053e9629129c533d3512d9992087f95a3ac71e464d552d63e8c711f90d83c6e8db543587df
   languageName: node
   linkType: hard
 
@@ -6797,9 +6798,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "expect@npm:27.2.0"
+"expect@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "expect@npm:27.2.1"
   dependencies:
     "@jest/types": ^27.1.1
     ansi-styles: ^5.0.0
@@ -6807,7 +6808,7 @@ __metadata:
     jest-matcher-utils: ^27.2.0
     jest-message-util: ^27.2.0
     jest-regex-util: ^27.0.6
-  checksum: 623b69e8e97bb55ecd0a27378431f42bb14f4f08a14b7497af870da38b86985ebde9d2fab026a9cb4983465a0bae5bb7d8a0c0df0384c745e9b12d5c239de2ca
+  checksum: cd39409f75ac3faa22b1839d38c60a6da3ca106d6b66aec1203e5a999b2de2922513fa46d9a044c0acc7c9a949566825f98f2d288fb22d5eb12b4f6069070fbc
   languageName: node
   linkType: hard
 
@@ -8530,9 +8531,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-circus@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-circus@npm:27.2.0"
+"jest-circus@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-circus@npm:27.2.1"
   dependencies:
     "@jest/environment": ^27.2.0
     "@jest/test-result": ^27.2.0
@@ -8541,34 +8542,34 @@ __metadata:
     chalk: ^4.0.0
     co: ^4.6.0
     dedent: ^0.7.0
-    expect: ^27.2.0
+    expect: ^27.2.1
     is-generator-fn: ^2.0.0
     jest-each: ^27.2.0
     jest-matcher-utils: ^27.2.0
     jest-message-util: ^27.2.0
-    jest-runtime: ^27.2.0
-    jest-snapshot: ^27.2.0
+    jest-runtime: ^27.2.1
+    jest-snapshot: ^27.2.1
     jest-util: ^27.2.0
     pretty-format: ^27.2.0
     slash: ^3.0.0
     stack-utils: ^2.0.3
     throat: ^6.0.1
-  checksum: c0db6ce3706e326e6b5df0aec8f4f27e4dc2e18de178b4cc2b740e3228df893f2754cdaf9b4a19bc29a06c7f408ad7d73b8c82e24baafb7e865209a2c9561faf
+  checksum: db77343cfdcfd13ada745cdbd7eeeb4b1f40f209eb939c8efce7f8146a4b9f631fd23fb292de0f4031e12b37eb15ff00e160e2e508b6b8643f5045ea8c1d0994
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-cli@npm:27.2.0"
+"jest-cli@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-cli@npm:27.2.1"
   dependencies:
-    "@jest/core": ^27.2.0
+    "@jest/core": ^27.2.1
     "@jest/test-result": ^27.2.0
     "@jest/types": ^27.1.1
     chalk: ^4.0.0
     exit: ^0.1.2
     graceful-fs: ^4.2.4
     import-local: ^3.0.2
-    jest-config: ^27.2.0
+    jest-config: ^27.2.1
     jest-util: ^27.2.0
     jest-validate: ^27.2.0
     prompts: ^2.0.1
@@ -8580,31 +8581,31 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: fa96bc41010591fa7b3fb78eab7fea1ce2231149e50c1685f5d4c840c255e5ede7389f7fefaf2a501f4ac64c924521b0e454b359db552a5fce0c0129f846728e
+  checksum: de2266e4a42425a531e54a626e27a4207d3099fc9369c498b8b8f5594a7a5999d68a46cbc7cd23e302039ccaac42fed04b36b3f4d06dcf0fff278c34f9f0e3da
   languageName: node
   linkType: hard
 
-"jest-config@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-config@npm:27.2.0"
+"jest-config@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-config@npm:27.2.1"
   dependencies:
     "@babel/core": ^7.1.0
-    "@jest/test-sequencer": ^27.2.0
+    "@jest/test-sequencer": ^27.2.1
     "@jest/types": ^27.1.1
-    babel-jest: ^27.2.0
+    babel-jest: ^27.2.1
     chalk: ^4.0.0
     deepmerge: ^4.2.2
     glob: ^7.1.1
     graceful-fs: ^4.2.4
     is-ci: ^3.0.0
-    jest-circus: ^27.2.0
+    jest-circus: ^27.2.1
     jest-environment-jsdom: ^27.2.0
     jest-environment-node: ^27.2.0
     jest-get-type: ^27.0.6
-    jest-jasmine2: ^27.2.0
+    jest-jasmine2: ^27.2.1
     jest-regex-util: ^27.0.6
     jest-resolve: ^27.2.0
-    jest-runner: ^27.2.0
+    jest-runner: ^27.2.1
     jest-util: ^27.2.0
     jest-validate: ^27.2.0
     micromatch: ^4.0.4
@@ -8614,7 +8615,7 @@ __metadata:
   peerDependenciesMeta:
     ts-node:
       optional: true
-  checksum: 3396de6d808fea4261e13e0320c081cfe78ad542809f94481b3262940e2ea6a05fede0b5e7bf28025d77e09326226eeb8ed9547362df4fb6d8bf81db7df413f5
+  checksum: 657b106544e5621d5dabe7fddf60e125937fedbbed754f535533a113b50112fa171183cb15afbe2910dec16b193ead8930f1f7b67a390a0459b7f9a90b79b6ca
   languageName: node
   linkType: hard
 
@@ -8712,9 +8713,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-jasmine2@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-jasmine2@npm:27.2.0"
+"jest-jasmine2@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-jasmine2@npm:27.2.1"
   dependencies:
     "@babel/traverse": ^7.1.0
     "@jest/environment": ^27.2.0
@@ -8724,17 +8725,17 @@ __metadata:
     "@types/node": "*"
     chalk: ^4.0.0
     co: ^4.6.0
-    expect: ^27.2.0
+    expect: ^27.2.1
     is-generator-fn: ^2.0.0
     jest-each: ^27.2.0
     jest-matcher-utils: ^27.2.0
     jest-message-util: ^27.2.0
-    jest-runtime: ^27.2.0
-    jest-snapshot: ^27.2.0
+    jest-runtime: ^27.2.1
+    jest-snapshot: ^27.2.1
     jest-util: ^27.2.0
     pretty-format: ^27.2.0
     throat: ^6.0.1
-  checksum: cfb7bb8f438f87f167b35eb0bd01a56c1bc4f82be99ceeb90808498bb274f9c89df4945248bd6fcaaf96639862fcb1e3168112d0595e4abd682efe35bc2137e0
+  checksum: a676885382eb2c85912e227da323cc821b1ff4cf0fa4aa6d0c42c25fe04bdf455f4a0e1ed3892acbf897c703de8adb6f655c0b123b39f90e11c2309620eca737
   languageName: node
   linkType: hard
 
@@ -8806,14 +8807,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-resolve-dependencies@npm:27.2.0"
+"jest-resolve-dependencies@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-resolve-dependencies@npm:27.2.1"
   dependencies:
     "@jest/types": ^27.1.1
     jest-regex-util: ^27.0.6
-    jest-snapshot: ^27.2.0
-  checksum: 164cc41b4ce23e2e7e549b79a5acce0549b5a31b1aeffab5cd4790e7171608874453f8d845a513dc97465d9bb553beb8706de23e33c960d7868e88b747a8d3bf
+    jest-snapshot: ^27.2.1
+  checksum: 7c771c03dac5b5cde6a77d3431e8ec3e8432120431f3d9d4e0fb8167dcf2214c4dbc112f8f9f8fb76725ad2ed31de24a1e8a5004a0850d50028806b569775328
   languageName: node
   linkType: hard
 
@@ -8835,14 +8836,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-runner@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-runner@npm:27.2.0"
+"jest-runner@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-runner@npm:27.2.1"
   dependencies:
     "@jest/console": ^27.2.0
     "@jest/environment": ^27.2.0
     "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     "@types/node": "*"
     chalk: ^4.0.0
@@ -8856,26 +8857,26 @@ __metadata:
     jest-leak-detector: ^27.2.0
     jest-message-util: ^27.2.0
     jest-resolve: ^27.2.0
-    jest-runtime: ^27.2.0
+    jest-runtime: ^27.2.1
     jest-util: ^27.2.0
     jest-worker: ^27.2.0
     source-map-support: ^0.5.6
     throat: ^6.0.1
-  checksum: d82f0b8f3d2eeeb1a951133e7f5823704725c1d09bfb61d42727039852f9aa70ecc1c215ee42bcbc6e0548f7c35a4ed57bebcbba9f8ec0665af45f7970f667e4
+  checksum: 76fb902d3aa6241f05a68fddef2cbb96d4ae3e4c7326c75ab19131821eb968c3f2e70b6685c6e4469b79d382a0e7d077f1ae7ca342471423ba042fdf648ab7e9
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-runtime@npm:27.2.0"
+"jest-runtime@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-runtime@npm:27.2.1"
   dependencies:
     "@jest/console": ^27.2.0
     "@jest/environment": ^27.2.0
     "@jest/fake-timers": ^27.2.0
-    "@jest/globals": ^27.2.0
+    "@jest/globals": ^27.2.1
     "@jest/source-map": ^27.0.6
     "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
@@ -8890,13 +8891,13 @@ __metadata:
     jest-mock: ^27.1.1
     jest-regex-util: ^27.0.6
     jest-resolve: ^27.2.0
-    jest-snapshot: ^27.2.0
+    jest-snapshot: ^27.2.1
     jest-util: ^27.2.0
     jest-validate: ^27.2.0
     slash: ^3.0.0
     strip-bom: ^4.0.0
     yargs: ^16.0.3
-  checksum: 0095eda680085c523f96362f7b28a3e60e328ef7100b8a03b598f142e06afa553ad987d96507c30b1984542dafffaa15ba29e5853a45eb83582e5b50d207907a
+  checksum: 3ca818a5db7219d5a32f828574899052f1b0393f0313a6d39d1419b9dc5334c273c244cd8d8c58f645c5dcfd4dfee33a2dcdc59c7e373860492c886bcae7506c
   languageName: node
   linkType: hard
 
@@ -8910,9 +8911,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-snapshot@npm:27.2.0"
+"jest-snapshot@npm:^27.2.1":
+  version: 27.2.1
+  resolution: "jest-snapshot@npm:27.2.1"
   dependencies:
     "@babel/core": ^7.7.2
     "@babel/generator": ^7.7.2
@@ -8920,13 +8921,13 @@ __metadata:
     "@babel/plugin-syntax-typescript": ^7.7.2
     "@babel/traverse": ^7.7.2
     "@babel/types": ^7.0.0
-    "@jest/transform": ^27.2.0
+    "@jest/transform": ^27.2.1
     "@jest/types": ^27.1.1
     "@types/babel__traverse": ^7.0.4
     "@types/prettier": ^2.1.5
     babel-preset-current-node-syntax: ^1.0.0
     chalk: ^4.0.0
-    expect: ^27.2.0
+    expect: ^27.2.1
     graceful-fs: ^4.2.4
     jest-diff: ^27.2.0
     jest-get-type: ^27.0.6
@@ -8938,7 +8939,7 @@ __metadata:
     natural-compare: ^1.4.0
     pretty-format: ^27.2.0
     semver: ^7.3.2
-  checksum: 5a46ef7e8300e672cd2e9b271a3bf34cc8be8266fd244bbcf314826c007fb684fad1864f37835d8f42c7b449353112738583a4495a7a0c049ca90c56b0326f23
+  checksum: 8e540260999ba762d167884d86649530d40216786c99c3b5df25e1459f86aeb67a32c0ddd16acbace6ebeb1f55c94d8564e2f6d5f6dbbc5f50dac209d62f7b9b
   languageName: node
   linkType: hard
 
@@ -9008,12 +9009,12 @@ __metadata:
   linkType: hard
 
 "jest@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest@npm:27.2.0"
+  version: 27.2.1
+  resolution: "jest@npm:27.2.1"
   dependencies:
-    "@jest/core": ^27.2.0
+    "@jest/core": ^27.2.1
     import-local: ^3.0.2
-    jest-cli: ^27.2.0
+    jest-cli: ^27.2.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -9021,7 +9022,7 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: 468749325b0f5cd8d3e6e6a92157f0b9bc6565efa99e7a5aff9fdf0f629f5107c6739e461429e680948786ce5ab7f78837c3b11a0489d92eb00aea0402cdb873
+  checksum: c9753ed1233c9318f9885e278924e15c018c50e5374b0e8d968cf652d6d1a2e86c53fa00cc01ce1bfaaffb762a48a7db9e7b98bcb28574493aeda5e852b35f5e
   languageName: node
   linkType: hard
 
@@ -10803,9 +10804,9 @@ __metadata:
   linkType: hard
 
 "node-releases@npm:^1.1.71, node-releases@npm:^1.1.75":
-  version: 1.1.75
-  resolution: "node-releases@npm:1.1.75"
-  checksum: 74028e7d193c9c5986b2f6bb51f4f6405a3f144599bbb19751c81faece52af8eb3f5abac40cbcd11ead44be3f856be125aa71fbb8dd8bf0c7f90caa94179ee51
+  version: 1.1.76
+  resolution: "node-releases@npm:1.1.76"
+  checksum: 10174cb880fffbb2896954599a2551da66127dd3c65703c827536fe9a4b4431545a9e3378c2006fb5ba59d0f0764ceff87c9f7eb0e84fabf7958411fccd0edd1
   languageName: node
   linkType: hard
 
@@ -13683,8 +13684,8 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "ts-loader@npm:^9.2.5":
-  version: 9.2.5
-  resolution: "ts-loader@npm:9.2.5"
+  version: 9.2.6
+  resolution: "ts-loader@npm:9.2.6"
   dependencies:
     chalk: ^4.1.0
     enhanced-resolve: ^5.0.0
@@ -13693,7 +13694,7 @@ resolve@^2.0.0-next.3:
   peerDependencies:
     typescript: "*"
     webpack: ^5.0.0
-  checksum: e39fab0caac55dc3c57789ea690aca687d033f0d202e2a27cc37aa0f57f987e7a70d033750d4079253e549fdd5c4379e3b5049c17dd1665ab89263dee06f2d1c
+  checksum: 309d8fb6348c0c3a7166d42c1238c585ede00f816155b24217dbca489406a72409395d7954bc5801ddb9ca71c71e7e0b2375dbc342337e0ab1a461944598a7fe
   languageName: node
   linkType: hard
 
@@ -14147,12 +14148,12 @@ typescript@^4.4.3:
   linkType: hard
 
 "unist-util-visit-parents@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "unist-util-visit-parents@npm:5.0.0"
+  version: 5.1.0
+  resolution: "unist-util-visit-parents@npm:5.1.0"
   dependencies:
     "@types/unist": ^2.0.0
     unist-util-is: ^5.0.0
-  checksum: 867bc66748c7b03f687ef111dee72b188024cefe375f612d05c1e64dcbf053109fae1aefe4bf253dc780811a484117c488458d8f87ef0b338ccccc647f66c653
+  checksum: 7c413dbb3dfcb679109fa8f0965d9abf117c3c53fa7b8823f68cac0ea53adbe98c1ce954d36c034e086c966b48b1d44d42c85f7bf6b42a032f728ac338929513
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With the release of ahooks version 2.10.10 the build seems broken. It seems a conflict got introduced with core/js used in the use-request package, an internal module used in ahooks.
Pinning ahooks to version 2.10.9 does not resolve the problem; this is due to a new version of use-request with a minor version increase was also published. A workaround is to pin also the version number of use-request to the previous version, which is 2.8.10.