### PR TITLE
Replace jsx=react with jsx=preserve

### DIFF
--- a/packages/app/components/src/icon/CustomIcon.tsx
+++ b/packages/app/components/src/icon/CustomIcon.tsx
@@ -1,7 +1,7 @@
 import { PageTypes } from '@app/types';
 import { IconName } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { getIconByName } from './Icon.svc';
 

--- a/packages/app/components/src/icon/Icon.svc.tsx
+++ b/packages/app/components/src/icon/Icon.svc.tsx
@@ -49,7 +49,6 @@ import {
   TouchApp,
   Warning,
 } from '@mui/icons-material';
-import React from 'react';
 
 export const getIconByName = (name: string) => {
   switch (name) {

--- a/packages/app/components/src/link/Link.tsx
+++ b/packages/app/components/src/link/Link.tsx
@@ -1,7 +1,7 @@
 import MuiLink, { LinkProps as MuiLinkProps } from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
-import React, { AnchorHTMLAttributes, forwardRef, ForwardRefRenderFunction } from 'react';
+import { AnchorHTMLAttributes, forwardRef, ForwardRefRenderFunction } from 'react';
 
 export interface NextLinkComposedProps
   extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,

--- a/packages/app/components/src/pdf/PDFWorker.tsx
+++ b/packages/app/components/src/pdf/PDFWorker.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { pdfjs } from 'react-pdf';
 
 export const PDFWorker: FC = ({ children }) => {

--- a/packages/app/components/src/pdf/StepperContent.tsx
+++ b/packages/app/components/src/pdf/StepperContent.tsx
@@ -2,7 +2,7 @@ import { HooksUtils } from '@app/render-utils';
 import { Box, Button, Grid } from '@mui/material';
 import dynamic from 'next/dynamic';
 import { PDFDocumentProxy } from 'pdfjs-dist';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { DocumentProps, PageProps } from 'react-pdf';
 
 import { Stepper, TranslationProps } from '../stepper/Stepper';

--- a/packages/app/components/src/portal/Portal.tsx
+++ b/packages/app/components/src/portal/Portal.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   cloneElement,
   createContext,
   FC,

--- a/packages/app/components/src/stepper/SimpleStepper.tsx
+++ b/packages/app/components/src/stepper/SimpleStepper.tsx
@@ -1,6 +1,6 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 import { Button, MobileStepper } from '@mui/material';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export interface TranslationProps {
   labelBack: string;

--- a/packages/app/components/src/stepper/Stepper.tsx
+++ b/packages/app/components/src/stepper/Stepper.tsx
@@ -1,6 +1,6 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 import { Button, MobileStepper } from '@mui/material';
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 
 export interface TranslationProps {
   labelBack: string;

--- a/packages/app/components/src/stepper/StepperContent.tsx
+++ b/packages/app/components/src/stepper/StepperContent.tsx
@@ -1,7 +1,7 @@
 import { ContentTypes } from '@app/types';
 import { CardContent, Grid, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 
 import { Stepper, TranslationProps } from './Stepper';
 import { getStepsLength, selectContent } from './StepperContent.svc';

--- a/packages/app/components/src/tag/Tag.tsx
+++ b/packages/app/components/src/tag/Tag.tsx
@@ -1,7 +1,7 @@
 import { ClassOutlined } from '@mui/icons-material';
 import { Chip } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export const Anchor = styled('span')(({ theme }) => ({
   position: 'absolute',

--- a/packages/app/layout/src/components/AppFrame.tsx
+++ b/packages/app/layout/src/components/AppFrame.tsx
@@ -1,5 +1,5 @@
 import { Navigation } from '@app/types';
-import React, { FC, useCallback } from 'react';
+import { FC, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { features } from '../features';

--- a/packages/app/layout/src/components/AppThemeProvider.tsx
+++ b/packages/app/layout/src/components/AppThemeProvider.tsx
@@ -1,7 +1,7 @@
 import { blue } from '@mui/material/colors';
 import CssBaseline from '@mui/material/CssBaseline';
 import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 
 const themeInitialOptions = {

--- a/packages/app/layout/src/components/AppWrapper.tsx
+++ b/packages/app/layout/src/components/AppWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { useAnalyticsOnRouteChange } from '../hooks/use-analytics-on-route-change';
 import { useResetScrollOnRouteChange } from '../hooks/use-reset-scroll-on-route-change';

--- a/packages/app/layout/src/components/BlogFrame.tsx
+++ b/packages/app/layout/src/components/BlogFrame.tsx
@@ -3,7 +3,7 @@ import { Navigation } from '@app/types';
 import { AppBar, Toolbar, Typography } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { AppFrameGrid } from './FrameGrid';
 import { HideOnScroll } from './toolbar/HideOnScroll';

--- a/packages/app/layout/src/components/BlogThemeProvider.tsx
+++ b/packages/app/layout/src/components/BlogThemeProvider.tsx
@@ -1,11 +1,7 @@
 import { CssBaseline, GlobalStyles } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import {
-  createTheme,
-  ThemeProvider as MuiThemeProvider,
-  useTheme
-} from '@mui/material/styles';
-import React, { FC, useMemo } from 'react';
+import { createTheme, ThemeProvider as MuiThemeProvider, useTheme } from '@mui/material/styles';
+import { FC, useMemo } from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 
 /**

--- a/packages/app/layout/src/components/DocsThemeProvider.tsx
+++ b/packages/app/layout/src/components/DocsThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { createTheme, ThemeProvider as MuiThemeProvider, useTheme } from '@mui/material/styles';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 export const DocsThemeProvider: FC = ({ children }) => {
   const theme = useTheme();

--- a/packages/app/layout/src/components/drawer/DesktopDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/DesktopDrawer.tsx
@@ -1,6 +1,6 @@
 import { Drawer } from '@mui/material';
 import { CSSObject, styled, Theme } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { DrawerProps } from '.';
 import { MAX_DRAWER_WIDTH, MIN_DRAWER_WIDTH } from '../../constants';

--- a/packages/app/layout/src/components/drawer/MobileDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/MobileDrawer.tsx
@@ -1,6 +1,6 @@
 import { SwipeableDrawer } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { DrawerProps } from '.';
 import { MAX_DRAWER_WIDTH } from '../../constants';

--- a/packages/app/layout/src/components/drawer/SwitchDrawer.tsx
+++ b/packages/app/layout/src/components/drawer/SwitchDrawer.tsx
@@ -5,7 +5,7 @@ import { Navigation } from '@app/types';
 import { Close, Home } from '@mui/icons-material';
 import { Divider, IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { DesktopDrawer, MobileDrawer } from '.';
 import { NAV_ITEM_INDICATOR_WIDTH } from '../../constants';

--- a/packages/app/layout/src/components/toolbar/AppBar.tsx
+++ b/packages/app/layout/src/components/toolbar/AppBar.tsx
@@ -3,7 +3,7 @@ import { GitHub, Menu } from '@mui/icons-material';
 import { AppBar as MuiAppBar, IconButton, Toolbar as MuiToolbar } from '@mui/material';
 import { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
 import { CSSObject, styled, Theme } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { MAX_DRAWER_WIDTH, TOOLBAR_HEIGHT } from '../../constants';
 import { HideOnScroll } from './HideOnScroll';

--- a/packages/app/layout/src/components/toolbar/LanguageLabel.tsx
+++ b/packages/app/layout/src/components/toolbar/LanguageLabel.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 interface LanguageLabelProps {
   label: string;

--- a/packages/app/layout/src/components/tree/Tree.tsx
+++ b/packages/app/layout/src/components/tree/Tree.tsx
@@ -1,7 +1,7 @@
 import { PageTypes } from '@app/types';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import TreeView from '@mui/lab/TreeView';
-import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
+import { FC, SyntheticEvent, useEffect, useState } from 'react';
 
 import { TreeContent } from './TreeContent';
 

--- a/packages/app/layout/src/components/tree/TreeContent.tsx
+++ b/packages/app/layout/src/components/tree/TreeContent.tsx
@@ -3,7 +3,7 @@ import { PageTypes } from '@app/types';
 import { Collapse } from '@mui/material';
 import { TransitionProps } from '@mui/material/transitions';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, Fragment } from 'react';
+import { FC, Fragment } from 'react';
 
 import { CustomTreeItem } from './CustomTreeItem';
 

--- a/packages/blog/components/src/post.tsx
+++ b/packages/blog/components/src/post.tsx
@@ -6,7 +6,7 @@ import { grey } from '@mui/material/colors';
 import { alpha, styled } from '@mui/material/styles';
 import { format } from 'date-fns';
 import isArray from 'lodash/isArray';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 export const PostWrapper = styled('li')(({ theme }) => ({
   borderRadius: theme.spacing(1),

--- a/packages/demonstrator/components/src/animation/components/AnimateHeight.tsx
+++ b/packages/demonstrator/components/src/animation/components/AnimateHeight.tsx
@@ -1,6 +1,6 @@
 import { HooksUtils } from '@app/render-utils';
 import { motion, Variants } from 'framer-motion';
-import React, { CSSProperties, FC, useMemo } from 'react';
+import { CSSProperties, FC, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { HeightVariants, THeightVariants } from '../types';

--- a/packages/demonstrator/components/src/cursor/Cursor.tsx
+++ b/packages/demonstrator/components/src/cursor/Cursor.tsx
@@ -1,6 +1,6 @@
 import { usePrevious } from 'ahooks';
 import { AnimatePresence, motion, useAnimation } from 'framer-motion';
-import React, { FC, useCallback, useEffect, useMemo, useRef } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { measure, measureOffset } from './Cursor.svc';
 import { click } from './dom-events';

--- a/packages/demonstrator/components/src/cursor/shapes/circle.tsx
+++ b/packages/demonstrator/components/src/cursor/shapes/circle.tsx
@@ -1,5 +1,5 @@
 import { motion, MotionStyle } from 'framer-motion';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 interface Props {
   radius: number;

--- a/packages/demonstrator/components/src/player/components/controls/NavigationControl.tsx
+++ b/packages/demonstrator/components/src/player/components/controls/NavigationControl.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, ArrowRight, Pause, PlayArrow } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { useStepDispatch, useStepState } from '../../context/StepProvider';
 

--- a/packages/demonstrator/components/src/player/components/progress/ProgressControl.tsx
+++ b/packages/demonstrator/components/src/player/components/progress/ProgressControl.tsx
@@ -1,7 +1,7 @@
 import { LABEL_BORDER_RADIUS } from '@app/layout';
 import { Slider } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { useStepDispatch, useStepState } from '../../context/StepProvider';
 import { Step } from '../../types';

--- a/packages/demonstrator/components/src/player/components/progress/TextProgressControl.tsx
+++ b/packages/demonstrator/components/src/player/components/progress/TextProgressControl.tsx
@@ -1,7 +1,7 @@
 import { LABEL_BORDER_RADIUS, LABEL_HEIGHT } from '@app/layout';
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { useStepState } from '../../context/StepProvider';
 import { Step } from '../../types';

--- a/packages/demonstrator/components/src/player/context/StepProvider.tsx
+++ b/packages/demonstrator/components/src/player/context/StepProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Dispatch, FC, ReactNode, useContext, useReducer } from 'react';
+import { createContext, Dispatch, FC, ReactNode, useContext, useReducer } from 'react';
 
 import { Action, initialState, reducer, StepState } from './reducer';
 

--- a/packages/demonstrator/components/src/sheet-next/components/Sheet.tsx
+++ b/packages/demonstrator/components/src/sheet-next/components/Sheet.tsx
@@ -1,6 +1,6 @@
 import { HooksUtils } from '@app/render-utils';
 import { AnimationOptions, motion, useAnimation, useMotionValue, Variants } from 'framer-motion';
-import React, { FC, useEffect, useMemo } from 'react';
+import { FC, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { getAutoHeightDuration, SheetProps } from './Sheet.svc';

--- a/packages/demonstrator/components/src/sheet-next/components/SheetWithAbsolutePosition.tsx
+++ b/packages/demonstrator/components/src/sheet-next/components/SheetWithAbsolutePosition.tsx
@@ -1,6 +1,6 @@
 import { HooksUtils } from '@app/render-utils';
 import { AnimationOptions, motion, useAnimation, useMotionValue, Variants } from 'framer-motion';
-import React, { FC, useEffect, useMemo } from 'react';
+import { FC, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { getAutoHeightDuration, SheetProps } from './Sheet.svc';

--- a/packages/demonstrator/components/src/sheet/components/Sheet.tsx
+++ b/packages/demonstrator/components/src/sheet/components/Sheet.tsx
@@ -1,5 +1,5 @@
 import { animate, AnimatePresence, AnimationOptions, useMotionValue } from 'framer-motion';
-import React, {
+import {
   Children,
   cloneElement,
   forwardRef,

--- a/packages/demonstrator/components/src/sheet/components/SheetContainer.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetContainer.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { useSheetContext } from '../context/SheetContext';
 

--- a/packages/demonstrator/components/src/sheet/components/SheetContent.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
 
 const Content = styled.div`

--- a/packages/demonstrator/components/src/sheet/components/SheetHeader.tsx
+++ b/packages/demonstrator/components/src/sheet/components/SheetHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
 
 const Header = styled.div`

--- a/packages/demonstrator/navigation/src/components/BottomNavigationControl.tsx
+++ b/packages/demonstrator/navigation/src/components/BottomNavigationControl.tsx
@@ -1,6 +1,6 @@
 import { Restore } from '@mui/icons-material';
 import { BottomNavigation, BottomNavigationAction } from '@mui/material';
-import React, { ChangeEvent, FC, useCallback } from 'react';
+import { ChangeEvent, FC, useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { features } from '../features';

--- a/packages/demonstrator/navigation/src/components/Navigation.tsx
+++ b/packages/demonstrator/navigation/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect } from 'react';
+import { FC, useCallback, useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 
 import { features } from '../features';

--- a/packages/demonstrators/social/components/src/input/ChromeInput.tsx
+++ b/packages/demonstrators/social/components/src/input/ChromeInput.tsx
@@ -3,7 +3,7 @@ import { features } from '@demonstrator/navigation';
 import { Fullscreen, FullscreenExit, InfoOutlined, ViewCarousel, ViewColumn } from '@mui/icons-material';
 import { Box, IconButton, InputAdornment, InputBase } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { FullScreenHandle } from 'react-full-screen';
 import { useRecoilState } from 'recoil';
 

--- a/packages/demonstrators/social/components/src/views/HeaderView.tsx
+++ b/packages/demonstrators/social/components/src/views/HeaderView.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material/styles';
-import React, { CSSProperties, FC } from 'react';
+import { CSSProperties, FC } from 'react';
 import { FullScreenHandle } from 'react-full-screen';
 
 import { ChromeInput } from '../input/ChromeInput';

--- a/packages/demonstrators/social/flow/src/FlowControl.tsx
+++ b/packages/demonstrators/social/flow/src/FlowControl.tsx
@@ -5,7 +5,7 @@ import { List, ListItem, ListSubheader, Paper, Typography } from '@mui/material'
 import { usePrevious } from 'ahooks';
 import get from 'lodash/get';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 export const ScenarioNavigator: FC = () => {

--- a/packages/demonstrators/social/flow/src/components/flow/Dock.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/Dock.tsx
@@ -1,6 +1,6 @@
 import { HooksUtils } from '@app/render-utils';
 import { features, Scroll } from '@demonstrators-social/shared';
-import React, { CSSProperties, FC, memo, useEffect } from 'react';
+import { CSSProperties, FC, memo, useEffect } from 'react';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { DockItem } from './DockItem';

--- a/packages/demonstrators/social/flow/src/components/flow/DockItem.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/DockItem.tsx
@@ -1,7 +1,7 @@
 import { HooksUtils } from '@app/render-utils';
 import { features } from '@demonstrators-social/shared';
 import { EffectRef } from '@huse/effect-ref';
-import React, { FC, memo, useEffect } from 'react';
+import { FC, memo, useEffect } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 import DockSliceWithArcher from './DockSlice';

--- a/packages/demonstrators/social/flow/src/components/flow/DockSlice.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/DockSlice.tsx
@@ -3,7 +3,7 @@ import { HooksUtils } from '@app/render-utils';
 import { features } from '@demonstrators-social/shared';
 import { EffectRef } from '@huse/effect-ref';
 import get from 'lodash/get';
-import React, { forwardRef, ForwardRefRenderFunction, MutableRefObject, useEffect } from 'react';
+import { forwardRef, ForwardRefRenderFunction, MutableRefObject, useEffect } from 'react';
 import { useRecoilCallback } from 'recoil';
 
 import { withArcher } from '../../hocs/with-archer';

--- a/packages/demonstrators/social/flow/src/components/flow/FlowBody.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/FlowBody.tsx
@@ -4,7 +4,7 @@ import { features as navigationFeatures } from '@demonstrator/navigation';
 import { features } from '@demonstrators-social/shared';
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
 const { InteractiveBox } = Box;

--- a/packages/demonstrators/social/flow/src/components/flow/FlowSurface.tsx
+++ b/packages/demonstrators/social/flow/src/components/flow/FlowSurface.tsx
@@ -1,6 +1,6 @@
 import { Archer } from '@app/archer';
 import { features, Scroll } from '@demonstrators-social/shared';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useRecoilCallback } from 'recoil';
 
 import { Dock } from './Dock';

--- a/packages/demonstrators/social/flow/src/components/player/FlowPlayControl.tsx
+++ b/packages/demonstrators/social/flow/src/components/player/FlowPlayControl.tsx
@@ -6,7 +6,7 @@ import { features as navigationFeatures, useNavigation } from '@demonstrator/nav
 import { features } from '@demonstrators-social/shared';
 import isFunction from 'lodash/isFunction';
 import dynamic from 'next/dynamic';
-import React, { FC, useCallback, useEffect, useMemo } from 'react';
+import { FC, useCallback, useEffect, useMemo } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 interface FlowPlayControlProps {

--- a/packages/demonstrators/social/flow/src/hocs/with-archer.tsx
+++ b/packages/demonstrators/social/flow/src/hocs/with-archer.tsx
@@ -1,5 +1,5 @@
 import { Archer, ArcherTypes } from '@app/archer';
-import React, { ComponentType } from 'react';
+import { ComponentType } from 'react';
 
 import { DockItemProps } from '../components/flow/DockItem';
 import { DockSliceProps } from '../components/flow/DockSlice';

--- a/packages/demonstrators/social/layout/src/App.tsx
+++ b/packages/demonstrators/social/layout/src/App.tsx
@@ -4,7 +4,7 @@ import { Components, features as navigationFeatures, TViewElement } from '@demon
 import { HeaderView } from '@demonstrators-social/components';
 import { generateData } from '@demonstrators-social/data';
 import { features } from '@demonstrators-social/shared';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { FullScreen, useFullScreenHandle } from 'react-full-screen';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { createGlobalStyle } from 'styled-components';

--- a/packages/demonstrators/social/layout/src/Demonstrator.tsx
+++ b/packages/demonstrators/social/layout/src/Demonstrator.tsx
@@ -1,6 +1,6 @@
 import { Portal } from '@app/components';
 import { animateCenterToLeftOrRight, animateFromLeftToCenter, animateFromRightToCenter } from '@demonstrator/navigation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { configure } from 'react-reparenting';
 
 import { App } from './App';

--- a/packages/demonstrators/social/layout/src/PlayerSheet.tsx
+++ b/packages/demonstrators/social/layout/src/PlayerSheet.tsx
@@ -5,7 +5,7 @@ import { features } from '@demonstrator/navigation';
 import { Components as FlowComponents } from '@demonstrators-social/flow';
 import { DonutLarge, Subscriptions } from '@mui/icons-material';
 import { Divider, Tab } from '@mui/material';
-import React, { FC, SyntheticEvent, useCallback, useEffect, useState } from 'react';
+import { FC, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 const {

--- a/packages/demonstrators/social/layout/src/PlayerSheetWithSnaps.tsx
+++ b/packages/demonstrators/social/layout/src/PlayerSheetWithSnaps.tsx
@@ -5,7 +5,7 @@ import { features } from '@demonstrator/navigation';
 import { Components as FlowComponents } from '@demonstrators-social/flow';
 import { DonutLarge, Subscriptions } from '@mui/icons-material';
 import { Button, Divider, Tab } from '@mui/material';
-import React, { FC, SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 const {

--- a/packages/demonstrators/social/layout/src/StoryPlayer.tsx
+++ b/packages/demonstrators/social/layout/src/StoryPlayer.tsx
@@ -1,6 +1,6 @@
 import { Player } from '@demonstrator/components';
 import { Components } from '@demonstrators-social/flow';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { LayoutVariants, PlayerSheet } from './PlayerSheet';

--- a/packages/demonstrators/social/layout/src/components/comment/Comments.tsx
+++ b/packages/demonstrators/social/layout/src/components/comment/Comments.tsx
@@ -5,7 +5,7 @@ import { Avatar, CardActions, CardContent, CardHeader, IconButton, IconButtonPro
 import { styled } from '@mui/material/styles';
 import { formatDistance } from 'date-fns';
 import { enGB } from 'date-fns/locale';
-import React, { forwardRef, ForwardRefRenderFunction, Fragment, useMemo, useState } from 'react';
+import { forwardRef, ForwardRefRenderFunction, Fragment, useMemo, useState } from 'react';
 
 type StyledIconButtonProps = IconButtonProps & {
   open: boolean;

--- a/packages/demonstrators/social/layout/src/components/comment/ContentEditor.tsx
+++ b/packages/demonstrators/social/layout/src/components/comment/ContentEditor.tsx
@@ -3,7 +3,7 @@ import { Button, Typography } from '@mui/material';
 import { useWindupString } from '@project-millipede/windups';
 import { ContentState, Editor, EditorState } from 'draft-js';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
 
 const longText = 'Hi @all, my name is Markus.';
 

--- a/packages/demonstrators/social/layout/src/components/post/Post.Render.svc.tsx
+++ b/packages/demonstrators/social/layout/src/components/post/Post.Render.svc.tsx
@@ -1,7 +1,6 @@
 import { EffectRef } from '@huse/effect-ref';
 import { Avatar, CardContent, CardHeader, CardMedia, Typography } from '@mui/material';
 import get from 'lodash/get';
-import React from 'react';
 
 export const getHeader = (
   ref: EffectRef<HTMLElement>,

--- a/packages/demonstrators/social/layout/src/components/post/Post.tsx
+++ b/packages/demonstrators/social/layout/src/components/post/Post.tsx
@@ -10,7 +10,7 @@ import { formatDistance } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import get from 'lodash/get';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
 

--- a/packages/demonstrators/social/layout/src/components/search/SimpleSearch.tsx
+++ b/packages/demonstrators/social/layout/src/components/search/SimpleSearch.tsx
@@ -2,7 +2,7 @@ import { INPUT_BORDER_RADIUS, INPUT_HEIGHT } from '@app/layout';
 import { Search } from '@mui/icons-material';
 import { IconButton, InputAdornment, InputBase } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { CSSProperties, FC } from 'react';
+import { CSSProperties, FC } from 'react';
 
 interface SimpleSearchProps {
   placeholder?: string;

--- a/packages/demonstrators/social/layout/src/components/timeline/Timeline.tsx
+++ b/packages/demonstrators/social/layout/src/components/timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import { Create } from '@mui/icons-material';
 import { Button, List } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, forwardRef, ForwardRefRenderFunction, useCallback, useEffect, useState } from 'react';
+import { FC, forwardRef, ForwardRefRenderFunction, useCallback, useEffect, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { ContentEditor } from '../comment/ContentEditor';

--- a/packages/demonstrators/social/layout/src/components/timeline/TimelineHeader.tsx
+++ b/packages/demonstrators/social/layout/src/components/timeline/TimelineHeader.tsx
@@ -3,7 +3,7 @@ import { Components as RenderComponents } from '@app/render-utils';
 import { features, Scroll } from '@demonstrators-social/shared';
 import { DynamicFeed, GroupWork } from '@mui/icons-material';
 import { Tab } from '@mui/material';
-import React, { FC, SyntheticEvent, useCallback } from 'react';
+import { FC, SyntheticEvent, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { SimpleSearch } from '../search';

--- a/packages/demonstrators/social/layout/src/views/LeftViewElement.tsx
+++ b/packages/demonstrators/social/layout/src/views/LeftViewElement.tsx
@@ -1,6 +1,6 @@
 import { ViewElementProps } from '@demonstrator/navigation';
 import { features } from '@demonstrators-social/shared';
-import React, { FC, memo, useLayoutEffect, useRef } from 'react';
+import { FC, memo, useLayoutEffect, useRef } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 import { Post } from '../components/post';

--- a/packages/demonstrators/social/layout/src/views/RightViewElement.tsx
+++ b/packages/demonstrators/social/layout/src/views/RightViewElement.tsx
@@ -1,6 +1,6 @@
 import { ViewElementProps } from '@demonstrator/navigation';
 import { features } from '@demonstrators-social/shared';
-import React, { FC, memo, useLayoutEffect, useRef } from 'react';
+import { FC, memo, useLayoutEffect, useRef } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 import { Post } from '../components/post';

--- a/packages/demonstrators/social/layout/src/views/ViewElement.tsx
+++ b/packages/demonstrators/social/layout/src/views/ViewElement.tsx
@@ -1,7 +1,7 @@
 import { ViewElementProps } from '@demonstrator/navigation';
 import { Components as FlowComponents } from '@demonstrators-social/flow';
 import { features } from '@demonstrators-social/shared';
-import React, { FC, memo } from 'react';
+import { FC, memo } from 'react';
 import { useRecoilValue } from 'recoil';
 
 const { FlowSurface } = FlowComponents;

--- a/packages/illustrations/src/components/ai/general/Concept1.tsx
+++ b/packages/illustrations/src/components/ai/general/Concept1.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../common';
 

--- a/packages/illustrations/src/components/ai/general/Concept2.tsx
+++ b/packages/illustrations/src/components/ai/general/Concept2.tsx
@@ -2,7 +2,7 @@ import { Archer, ArcherTypes } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../common';
 import { Instrument } from './components/Instrument';

--- a/packages/illustrations/src/components/ai/general/Concept3.tsx
+++ b/packages/illustrations/src/components/ai/general/Concept3.tsx
@@ -1,6 +1,6 @@
 import { Archer } from '@app/archer';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Instrument } from './components/Instrument';
 import { Render } from './components/Render';

--- a/packages/illustrations/src/components/ai/general/components/Instrument.tsx
+++ b/packages/illustrations/src/components/ai/general/components/Instrument.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../../common';
 import { Connect } from '../Concept2';

--- a/packages/illustrations/src/components/ai/general/components/Render.tsx
+++ b/packages/illustrations/src/components/ai/general/components/Render.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../../common';
 

--- a/packages/illustrations/src/components/ai/general/components/Target.tsx
+++ b/packages/illustrations/src/components/ai/general/components/Target.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../../common';
 import { Connect } from '../Concept2';

--- a/packages/illustrations/src/components/ai/reverse/ReversePrincipal.tsx
+++ b/packages/illustrations/src/components/ai/reverse/ReversePrincipal.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../common';
 

--- a/packages/illustrations/src/components/ai/reverse/hooks/MethodHooking.tsx
+++ b/packages/illustrations/src/components/ai/reverse/hooks/MethodHooking.tsx
@@ -2,7 +2,7 @@ import { Stepper } from '@app/components';
 import { ContentTypes } from '@app/types';
 import isArray from 'lodash/isArray';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { FunctionBeahvior } from './components/FunctionBeahvior';
 import { FunctionBeahviorHook } from './components/FunctionBeahviorHook';

--- a/packages/illustrations/src/components/ai/reverse/hooks/components/FunctionBeahvior.tsx
+++ b/packages/illustrations/src/components/ai/reverse/hooks/components/FunctionBeahvior.tsx
@@ -1,7 +1,7 @@
 import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TitleUnstyled } from '../../../../common';
 

--- a/packages/illustrations/src/components/ai/reverse/hooks/components/FunctionBeahviorHook.tsx
+++ b/packages/illustrations/src/components/ai/reverse/hooks/components/FunctionBeahviorHook.tsx
@@ -1,7 +1,7 @@
 import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TitleUnstyled } from '../../../../common';
 

--- a/packages/illustrations/src/components/discover-more/team/Board.tsx
+++ b/packages/illustrations/src/components/discover-more/team/Board.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import { Translate } from 'next-translate';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export const getActiveCoreMembers = (t: Translate) => [
   {

--- a/packages/illustrations/src/components/guides/disinformation/SpectrumOfFalseInformation.tsx
+++ b/packages/illustrations/src/components/guides/disinformation/SpectrumOfFalseInformation.tsx
@@ -1,5 +1,5 @@
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { VictoryAxis, VictoryBar, VictoryChart, VictoryTheme } from 'victory';
 
 export const SpectrumOfFalseInformation: FC = () => {

--- a/packages/illustrations/src/components/guides/research/paper/Publications.tsx
+++ b/packages/illustrations/src/components/guides/research/paper/Publications.tsx
@@ -5,7 +5,7 @@ import { styled } from '@mui/material/styles';
 import isArray from 'lodash/isArray';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
-import React, { FC, Fragment, useState } from 'react';
+import { FC, Fragment, useState } from 'react';
 
 export const StyledTableCell = dynamic(() => import('./StyledTableCell'), {
   ssr: false

--- a/packages/illustrations/src/components/perspective/strategy/InterdisciplinaryApproach.tsx
+++ b/packages/illustrations/src/components/perspective/strategy/InterdisciplinaryApproach.tsx
@@ -2,7 +2,7 @@ import { Archer } from '@app/archer';
 import { Box } from '@app/components';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Title } from '../../common';
 

--- a/packages/illustrations/src/components/pet/dataflow/comparison/DataflowComparison.tsx
+++ b/packages/illustrations/src/components/pet/dataflow/comparison/DataflowComparison.tsx
@@ -2,7 +2,7 @@ import { Stepper } from '@app/components';
 import { ContentTypes } from '@app/types';
 import isArray from 'lodash/isArray';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Svg as Step1 } from './assets/Data-Flow-Step1.svg';
 import { Svg as Step2 } from './assets/Data-Flow-Step2.svg';

--- a/packages/illustrations/src/components/pidp/approach/by-example/ByExample.tsx
+++ b/packages/illustrations/src/components/pidp/approach/by-example/ByExample.tsx
@@ -2,7 +2,7 @@ import { Stepper } from '@app/components';
 import { ContentTypes } from '@app/types';
 import isArray from 'lodash/isArray';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Svg as Step1 } from './assets/Pages-Step-1.svg';
 import { Svg as Step2 } from './assets/Pages-Step-2.svg';

--- a/packages/illustrations/src/components/security/attack-vectors/comparison/AttackVectorsComparison.tsx
+++ b/packages/illustrations/src/components/security/attack-vectors/comparison/AttackVectorsComparison.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@mui/material/styles';
 import { Mdx } from '@page/layout';
 import isArray from 'lodash/isArray';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export const AttackVectorsComparison: FC = () => {
   const theme = useTheme();

--- a/packages/illustrations/tsconfig.json
+++ b/packages/illustrations/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "preserve",
     "skipLibCheck": true
   },
   "include": ["additional.d.ts", "**/*.ts", "**/*.tsx"]

--- a/packages/page/components/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/page/components/src/breadcrumbs/Breadcrumbs.tsx
@@ -4,7 +4,7 @@ import { NavigateNext } from '@mui/icons-material';
 import { Breadcrumbs as MuiBreadcrumbs, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 export interface BreadCrumb {
   link: string;

--- a/packages/page/components/src/breadcrumbs/CustomBreadcrumbs.tsx
+++ b/packages/page/components/src/breadcrumbs/CustomBreadcrumbs.tsx
@@ -3,7 +3,7 @@ import { Navigation } from '@app/types';
 import { Breadcrumbs as MuiBreadcrumbs, Chip, ChipProps } from '@mui/material';
 import { emphasize, styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 export interface BreadCrumb {
   link: string;

--- a/packages/page/components/src/grid/Item.tsx
+++ b/packages/page/components/src/grid/Item.tsx
@@ -4,7 +4,7 @@ import { Avatar, IconButton, Typography } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import isArray from 'lodash/isArray';
 import { useRouter } from 'next/router';
-import React from 'react';
+import { FC } from 'react';
 
 // const useStyles = makeStyles((theme: Theme) => ({
 //   ==> unresolved
@@ -53,12 +53,12 @@ export const Note = styled(Typography)(({ theme }) => ({
   }
 }));
 
-export const Item = ({
+export const Item: FC<ContentTypes.OverviewProps> = ({
   title,
   description,
   link,
   icon
-}: ContentTypes.OverviewProps) => {
+}) => {
   const theme = useTheme();
 
   const { push } = useRouter();

--- a/packages/page/components/src/share/Icon.tsx
+++ b/packages/page/components/src/share/Icon.tsx
@@ -1,7 +1,11 @@
 import { AlternateEmail, Assignment, Facebook, LinkedIn, Twitter, WhatsApp } from '@mui/icons-material';
-import React from 'react';
+import { FC } from 'react';
 
-export const Icon = ({ id }) => {
+interface IconProps {
+  id: string;
+}
+
+export const Icon: FC<IconProps> = ({ id }) => {
   switch (id) {
     case 'copy-link':
       return <Assignment />;

--- a/packages/page/components/src/share/Share.tsx
+++ b/packages/page/components/src/share/Share.tsx
@@ -11,7 +11,7 @@ import copy from 'copy-to-clipboard';
 import isArray from 'lodash/isArray';
 import { Translate } from 'next-translate';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, SyntheticEvent, useCallback, useMemo } from 'react';
+import { FC, SyntheticEvent, useCallback, useMemo } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import { features } from '../features';

--- a/packages/page/components/src/snackbar/Snackbar.tsx
+++ b/packages/page/components/src/snackbar/Snackbar.tsx
@@ -1,5 +1,5 @@
 import { Alert, Snackbar as MuiSnackbar } from '@mui/material';
-import React, { FC, SyntheticEvent, useCallback } from 'react';
+import { FC, SyntheticEvent, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { features } from '../features';

--- a/packages/page/components/tsconfig.json
+++ b/packages/page/components/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "preserve",
     "skipLibCheck": true
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/packages/page/landing/src/animation/framer/components/container/BottomRevealMin.tsx
+++ b/packages/page/landing/src/animation/framer/components/container/BottomRevealMin.tsx
@@ -1,5 +1,5 @@
 import { motion, useAnimation, Variants } from 'framer-motion';
-import React, { FC, ReactNode, useEffect } from 'react';
+import { FC, ReactNode, useEffect } from 'react';
 
 export interface BottomRevealMinProps {
   id: string;

--- a/packages/page/landing/src/animation/framer/components/container/TopRevealMin.tsx
+++ b/packages/page/landing/src/animation/framer/components/container/TopRevealMin.tsx
@@ -1,5 +1,5 @@
 import { motion, useAnimation, Variants } from 'framer-motion';
-import React, { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 export interface TopRevealMinProps {
   id: string;

--- a/packages/page/landing/src/animation/framer/components/text/TopReveal.tsx
+++ b/packages/page/landing/src/animation/framer/components/text/TopReveal.tsx
@@ -2,7 +2,7 @@ import { StringUtil } from '@app/utils';
 import { Typography } from '@mui/material';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import isArray from 'lodash/isArray';
-import React from 'react';
+import { FC } from 'react';
 
 interface TopRevealProps {
   id: string;
@@ -16,7 +16,7 @@ interface TopRevealProps {
   loop?: boolean;
 }
 
-export const TopReveal = (props: TopRevealProps) => {
+export const TopReveal: FC<TopRevealProps> = props => {
   const {
     id,
     text,

--- a/packages/page/landing/src/components/Topics.tsx
+++ b/packages/page/landing/src/components/Topics.tsx
@@ -6,7 +6,7 @@ import { Item } from '@page/components';
 import groupArray from 'group-array';
 import get from 'lodash/get';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { translateObject } from './TranslateService';
 

--- a/packages/page/landing/src/components/TopicsDetail.tsx
+++ b/packages/page/landing/src/components/TopicsDetail.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Topics } from './Topics';
 

--- a/packages/page/landing/src/components/TopicsHead.tsx
+++ b/packages/page/landing/src/components/TopicsHead.tsx
@@ -1,7 +1,7 @@
 import { Components } from '@app/render-utils';
 import { ContentTypes } from '@app/types';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TopicsViewDesktop } from './TopicsViewDesktop';
 import { TopicsViewMobile } from './TopicsViewMobile';

--- a/packages/page/landing/src/components/TopicsViewDesktop.tsx
+++ b/packages/page/landing/src/components/TopicsViewDesktop.tsx
@@ -1,7 +1,7 @@
 import { CustomIcon, HiddenUnderlineLink } from '@app/components';
 import { ContentTypes } from '@app/types';
 import { Box, Grid, IconButton } from '@mui/material';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TopReveal } from '../animation/framer/components/text/TopReveal';
 

--- a/packages/page/landing/src/components/TopicsViewMobile.tsx
+++ b/packages/page/landing/src/components/TopicsViewMobile.tsx
@@ -1,5 +1,5 @@
 import { ContentTypes } from '@app/types';
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 
 import { useTimeout } from '../hooks';
 import { FullScreenInterface } from '../interface/FullScreenInterfaceByComponent';

--- a/packages/page/landing/src/interface/FullScreenInterfaceByComponent/index.tsx
+++ b/packages/page/landing/src/interface/FullScreenInterfaceByComponent/index.tsx
@@ -1,5 +1,5 @@
 import { ContentTypes } from '@app/types';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import Window from '../windowByComponent';
 

--- a/packages/page/landing/src/interface/windowByComponent.tsx
+++ b/packages/page/landing/src/interface/windowByComponent.tsx
@@ -1,7 +1,7 @@
 import { CustomIcon, HiddenUnderlineLink } from '@app/components';
 import { ContentTypes } from '@app/types';
 import { Box, IconButton } from '@mui/material';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TopReveal } from '../animation/framer/components/text/TopReveal';
 

--- a/packages/page/landing/tsconfig.json
+++ b/packages/page/landing/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "preserve",
     "skipLibCheck": true
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/packages/page/layout/src/components/AppContentFooter.tsx
+++ b/packages/page/layout/src/components/AppContentFooter.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, ChevronRight } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 export const Footer = styled(Box)(({ theme }) => {
   return {

--- a/packages/page/layout/src/components/AppContentHeader.tsx
+++ b/packages/page/layout/src/components/AppContentHeader.tsx
@@ -2,7 +2,7 @@ import { Navigation, PageTypes } from '@app/types';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Breadcrumbs, Share } from '@page/components';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 interface AppContentHeaderProps {
   slug: Array<string>;

--- a/packages/page/layout/src/components/AppContentSubHeader.tsx
+++ b/packages/page/layout/src/components/AppContentSubHeader.tsx
@@ -1,6 +1,6 @@
 import { PageTypes } from '@app/types';
 import { Typography } from '@mui/material';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 interface AppContentSubHeaderProps {
   timeToRead?: PageTypes.ReadingTime;

--- a/packages/page/layout/src/components/AppHead.tsx
+++ b/packages/page/layout/src/components/AppHead.tsx
@@ -2,7 +2,7 @@ import { PageTypes } from '@app/types';
 import useTranslation from 'next-translate/useTranslation';
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 interface HeadProps {
   metaData: PageTypes.MetaData;

--- a/packages/page/layout/src/components/AppTableOfContents.tsx
+++ b/packages/page/layout/src/components/AppTableOfContents.tsx
@@ -4,7 +4,7 @@ import { styled, Theme } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import { TocEntry } from '@stefanprobst/remark-extract-toc';
 import useTranslation from 'next-translate/useTranslation';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TocComponent } from './toc/TocComponent';
 

--- a/packages/page/layout/src/components/Editpage.tsx
+++ b/packages/page/layout/src/components/Editpage.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 const LOCALES = { zh: 'zh-CN', pt: 'pt-BR', es: 'es-ES' };
 const CROWDIN_ROOT_URL = 'https://crowdin.com/project/project-millipede';

--- a/packages/page/layout/src/components/HomeFooter.tsx
+++ b/packages/page/layout/src/components/HomeFooter.tsx
@@ -4,7 +4,7 @@ import { grey } from '@mui/material/colors';
 import { styled, useTheme } from '@mui/material/styles';
 import useTranslation from 'next-translate/useTranslation';
 import getConfig from 'next/config';
-import React from 'react';
+import { FC } from 'react';
 
 export const Link = styled(HiddenUnderlineLink)({
   fontSize: '0.875rem',
@@ -31,7 +31,7 @@ export const StyledGrid = styled(Grid)<GridProps>(({ theme }) => ({
   }
 }));
 
-export const HomeFooter = () => {
+export const HomeFooter: FC = () => {
   const { t } = useTranslation();
 
   const theme = useTheme();

--- a/packages/page/layout/src/components/head/InteractiveHead.tsx
+++ b/packages/page/layout/src/components/head/InteractiveHead.tsx
@@ -2,7 +2,7 @@ import { HiddenUnderlineLink } from '@app/components';
 import { CollectionUtil } from '@app/utils';
 import { Variant } from '@mui/material/styles/createTypography';
 import { useRouter } from 'next/router';
-import React, { FC, useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useRecoilCallback } from 'recoil';
 

--- a/packages/page/layout/src/components/toc/TocComponent.tsx
+++ b/packages/page/layout/src/components/toc/TocComponent.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material/styles';
 import { TocEntry } from '@stefanprobst/remark-extract-toc';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { TocLink } from './TocLink';
 

--- a/packages/page/layout/src/components/toc/TocLink.tsx
+++ b/packages/page/layout/src/components/toc/TocLink.tsx
@@ -3,7 +3,7 @@ import { Typography, TypographyProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { LinkProps } from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
-import React, { FC } from 'react';
+import { ElementType, FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { features } from '../../features';
@@ -16,7 +16,7 @@ type TypographyEnhancedProps = TypographyProps &
     // The types for the (styled) typography component are broken- type-inference is not working as expected.
     // Specifying the component property on styled typography is not possible; the property does not exist.
     // The utilization of the component property works, e.g., on a styled box component as expected.
-    component?: React.ElementType;
+    component?: ElementType;
   };
 
 const TocLabel = styled(Typography, {

--- a/packages/page/layout/src/mdx/MdxBlog.tsx
+++ b/packages/page/layout/src/mdx/MdxBlog.tsx
@@ -7,7 +7,7 @@ import { styled } from '@mui/material/styles';
 import { Snackbar } from '@page/components';
 import { Toc } from '@stefanprobst/remark-extract-toc';
 import { format } from 'date-fns';
-import React, { FC, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 import { AppTableOfContents } from '../components';
 import { AppContentFooter } from '../components/AppContentFooter';

--- a/packages/page/layout/src/mdx/MdxDocs.tsx
+++ b/packages/page/layout/src/mdx/MdxDocs.tsx
@@ -5,7 +5,7 @@ import { Container } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Snackbar } from '@page/components';
 import { Toc } from '@stefanprobst/remark-extract-toc';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { AppTableOfContents } from '../components';
 import { AppContentFooter } from '../components/AppContentFooter';

--- a/packages/page/layout/src/mdx/MdxElement.tsx
+++ b/packages/page/layout/src/mdx/MdxElement.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@mui/material';
 import { blue } from '@mui/material/colors';
 import { styled } from '@mui/material/styles';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export const h1: FC = ({ children }) => (
   <Typography variant='h1'>{children}</Typography>

--- a/packages/page/layout/src/mdx/MdxHeader.tsx
+++ b/packages/page/layout/src/mdx/MdxHeader.tsx
@@ -2,7 +2,7 @@ import { Components as RenderComponents } from '@app/render-utils';
 import { Typography } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
 import { Components } from '@page/layout';
-import React, { FC, memo } from 'react';
+import { FC, memo } from 'react';
 
 const {
   Media: { Media }

--- a/packages/page/layout/tsconfig.json
+++ b/packages/page/layout/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "preserve",
     "skipLibCheck": true
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/packages/render-utils/src/hocs/with-forward-ref.tsx
+++ b/packages/render-utils/src/hocs/with-forward-ref.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ComponentType,
   forwardRef,
   ForwardRefExoticComponent,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,7 +9,7 @@ import { config } from '@fortawesome/fontawesome-svg-core';
 import { NextComponentType } from 'next';
 import I18nProvider from 'next-translate/I18nProvider';
 import { AppContext, AppInitialProps } from 'next/app';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import { AnalyticsProvider } from 'use-analytics';
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Components } from '@app/render-utils';
 import createEmotionServer from '@emotion/server/create-instance';
 import { AppType } from 'next/dist/shared/lib/utils';
 import NextDocument, { DocumentContext, DocumentInitialProps, Head, Html, Main, NextScript } from 'next/document';
-import React, { Children } from 'react';
+import { Children } from 'react';
 import { ServerStyleSheet as StyledComponentSheets } from 'styled-components';
 
 import { createEmotionCache } from '../docs/src/lib/emotion';

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from 'next';
-import React from 'react';
 
 interface ErrorProps {
   statusCode: number;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -7,7 +7,7 @@ import { styled } from '@mui/material/styles';
 import { compareDesc } from 'date-fns';
 import { GetStaticProps } from 'next';
 import { mergeProps } from 'next-merge-props';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import { GetStaticContentProps, getStaticContentPropsBlogIndex } from '../../docs/src/lib/getStaticContentProps';
 import { GetStaticNavigationProps } from '../../docs/src/lib/getStaticNavigationProps';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import { Components } from '@page/layout';
 import { GetStaticProps } from 'next';
 import { mergeProps } from 'next-merge-props';
 import useTranslation from 'next-translate/useTranslation';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { GetStaticNavigationProps, getStaticNavigationProps } from '../docs/src/lib/getStaticNavigationProps';


### PR DESCRIPTION
Move code to new jsx-transform

modules app/components and app/layout

Move code to new jsx-transform

modules demonstrator/components and demonstrator/navigation

Move code to new jsx-transform

modules and submodules of demonstrators/social

Move code to new jsx-transform

modules blog/components and illustrations

Move code to new jsx-transform

modules page/component, page/landing and page/layout

Move code to new jsx-transform

Left over changes