### PR TITLE
Avoid re-rendering on hash-change

### DIFF
--- a/packages/app/layout/src/components/Analytics.tsx
+++ b/packages/app/layout/src/components/Analytics.tsx
@@ -1,0 +1,9 @@
+import { FC } from 'react';
+
+import { useAnalyticsOnRouteChange } from '../hooks/use-analytics-on-route-change';
+
+export const Analytics: FC = () => {
+  useAnalyticsOnRouteChange();
+
+  return null;
+};

--- a/packages/app/layout/src/components/AppWrapper.tsx
+++ b/packages/app/layout/src/components/AppWrapper.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 
-import { useAnalyticsOnRouteChange } from '../hooks/use-analytics-on-route-change';
 import { useResetScrollOnRouteChange } from '../hooks/use-reset-scroll-on-route-change';
 import { useSmoothScroll } from '../hooks/use-smooth-scroll';
 
@@ -9,8 +8,5 @@ export const AppWrapper: FC = ({ children }) => {
   useSmoothScroll();
 
   useResetScrollOnRouteChange();
-
-  useAnalyticsOnRouteChange();
-
   return <>{children}</>;
 };

--- a/packages/app/layout/src/index.ts
+++ b/packages/app/layout/src/index.ts
@@ -3,6 +3,7 @@ export { AppFrame } from './components/AppFrame';
 export { BlogFrame } from './components/BlogFrame';
 
 export { AppWrapper } from './components/AppWrapper';
+export { Analytics } from './components/Analytics';
 export { AppThemeProvider } from './components/AppThemeProvider';
 export { DocsThemeProvider } from './components/DocsThemeProvider';
 export { BlogThemeProvider } from './components/BlogThemeProvider';


### PR DESCRIPTION
Navigation to anchors should not cause any re-render; however, changing the hash through NextJs building blocks Link and Router does cause a re-render.

The solution is to memoize the Component using a subset of the properties of the router object (locale and slug) as dependables.

Other modifications move the analytics provider as the top parent component towards being a sibling next to the actual component.